### PR TITLE
Record tool problems once, report them in plain language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
               c.stdin.write(JSON.stringify({jsonrpc:"2.0",method:"notifications/initialized"})+"\n");
               const t=await send("tools/list",{});
               const n=t.result.tools.length;
-              if(n<60){console.error(`expected >=60 tools, got ${n}`);process.exit(1);}
+              if(n<63){console.error(`expected >=63 tools, got ${n}`);process.exit(1);}
               console.log(`${n} tools on ${process.platform}`);
               c.kill();process.exit(0);
             })();'
@@ -73,5 +73,28 @@ jobs:
           node packages/mcp-server/dist/index.js init ci-project --with-mcp
           test -f ci-project/CLAUDE.md
           test -f ci-project/.claude/skills/house-style/SKILL.md
+          test -f ci-project/.claude/commands/report-ae-issue.md
           test -f ci-project/.mcp.json
           echo "scaffold ok"
+
+      # The journal is the one piece of state this server owns, and its round
+      # trip has to survive a Windows path and a hand-edited file.
+      - name: Issue journal round-trips
+        shell: bash
+        env:
+          AE_MCP_HOME: ${{ runner.temp }}/ae-mcp-home
+        run: |
+          node -e '
+            import("./packages/mcp-server/dist/issues/journal.js").then(j=>{
+              const first=j.logIssue({title:"Example: a tool failed oddly",symptom:"boom",workaround:"do it the other way",cause:"because",tools:["run_jsx"]});
+              if(first.previouslyLogged||first.occurrences!==1) throw new Error("first log should be new");
+              j.markReported(first.id,"https://example.invalid/1");
+              const again=j.logIssue({title:"Example: A TOOL FAILED ODDLY!",symptom:"boom again",workaround:"same"});
+              if(again.id!==first.id) throw new Error(`title should map to one id: ${again.id} vs ${first.id}`);
+              if(again.occurrences!==2) throw new Error("re-log should count the sighting");
+              if(!again.reported) throw new Error("a new sighting must not un-report an entry");
+              const all=j.listIssues("all"), open=j.listIssues("unreported");
+              if(all.count!==1||open.count!==0) throw new Error(`status filter wrong: ${all.count}/${open.count}`);
+              if(all.issues[0].cause!=="because") throw new Error("a known cause must survive a sighting logged without one");
+              console.log(`journal ok at ${all.dir}`);
+            }).catch(e=>{console.error(e);process.exit(1);});'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
           AE_MCP_HOME: ${{ runner.temp }}/ae-mcp-home
         run: |
           node -e '
+            const fs=require("fs"),path=require("path");
             import("./packages/mcp-server/dist/issues/journal.js").then(j=>{
               const first=j.logIssue({title:"Example: a tool failed oddly",symptom:"boom",workaround:"do it the other way",cause:"because",tools:["run_jsx"]});
               if(first.previouslyLogged||first.occurrences!==1) throw new Error("first log should be new");
@@ -96,5 +97,8 @@ jobs:
               const all=j.listIssues("all"), open=j.listIssues("unreported");
               if(all.count!==1||open.count!==0) throw new Error(`status filter wrong: ${all.count}/${open.count}`);
               if(all.issues[0].cause!=="because") throw new Error("a known cause must survive a sighting logged without one");
-              console.log(`journal ok at ${all.dir}`);
+              // Untracked by construction, not by asking the project to ignore it.
+              const ignore=path.join(all.dir,"..",".gitignore");
+              if(fs.readFileSync(ignore,"utf8").trim()!=="*") throw new Error(`journal must ignore itself: ${ignore}`);
+              console.log(`journal ok at ${all.dir} (scope ${all.scope})`);
             }).catch(e=>{console.error(e);process.exit(1);});'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file is for future Claude Code sessions working in this repo. Humans readin
 
 ## What this project is
 
-An MCP server that lets an LLM drive Adobe After Effects 2026: comps, layers, transforms, keyframes (with full interpolation/easing/tangent control), expressions, effects, text, shapes, masks, markers, one-off screenshots, bulk batches. 60 tools. macOS and Windows — the only two platforms AE runs on.
+An MCP server that lets an LLM drive Adobe After Effects 2026: comps, layers, transforms, keyframes (with full interpolation/easing/tangent control), expressions, effects, text, shapes, masks, markers, one-off screenshots, bulk batches. 63 tools. macOS and Windows — the only two platforms AE runs on.
 
 It ships three ways: as an npm package (`npx @engine-room/after-effects-mcp`), as a Claude Code plugin (this repo is also its marketplace), and as a git checkout for development.
 
@@ -45,11 +45,12 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 | `packages/mcp-server/src/tools/descriptions.ts` | All tool descriptions in one file — including the verbatim screenshot guidance. |
 | `packages/mcp-server/src/bridge/{httpClient,wsClient,discovery}.ts` | Bridge plumbing. |
 | `packages/mcp-server/src/jobs/manager.ts` | In-memory job table, `waitFor(jobId)` for the `await_job` tool. |
+| `packages/mcp-server/src/issues/journal.ts` | The cross-session issue journal at `~/.after-effects-mcp/issues/`. Backs `log_issue` / `list_known_issues` / `mark_issue_reported`. Home directory, not the project folder: the knowledge is about the tools, so it should follow the user across projects, and a home directory is untracked by construction. `AE_MCP_HOME` overrides the root (used by the CI check). |
 | `packages/mcp-server/src/setup/{check,install,paths}.ts` | Backs `check_setup` / `setup_panel`. Never touches the bridge — it exists for the case where the panel isn't installed yet. |
 | `packages/mcp-server/src/setup/platform.ts` | **The only place macOS and Windows diverge** (PlayerDebugMode storage, AE process detection). Plus `cepExtensionsDir()` in `paths.ts`. Keep platform branching here — do not scatter `process.platform` through the codebase. |
 | `scripts/lib/setup.mjs` | Loads the compiled setup module so the dev scripts (`doctor`, `install-panel`, `enable-debug`) reuse the same platform logic the MCP tools use instead of keeping a second copy. |
 | `packages/mcp-server/src/cli/init.ts` | `npx @engine-room/after-effects-mcp init <dir>` project scaffold. Templates are inline string constants so nothing extra has to be packaged. |
-| `plugin/` | The Claude Code plugin: `.mcp.json` + `skills/{after-effects,ae-setup}`. Skills carry tool knowledge only — never anyone's house style. |
+| `plugin/` | The Claude Code plugin: `.mcp.json` + `skills/{after-effects,ae-setup}` + `commands/report-ae-issue.md`. Skills carry tool knowledge only — never anyone's house style. |
 | `.claude-plugin/marketplace.json` | Marketplace catalog. Users add this repo, then install `after-effects@engine-room`. |
 | `scripts/bundle-jsx.mjs` | Concatenates `packages/jsx/*.jsx` in dependency order into `packages/ae-panel/jsx/bundle.jsx`. Run via `npm run build:jsx`. |
 | `scripts/prepare-package.mjs` | `prepack` hook. esbuild-bundles the server to `bin/server.js` (inlining `@engineroom/shared`, which is never published separately) and vendors the panel to `panel/`. |
@@ -71,7 +72,7 @@ The `server.ts` tool registration loop reads `OpSchemas`, so no MCP-side wiring 
 
 - **Vision** (`screenshot_frame`, `screenshot_layer`): JSX returns `{path, width, height, time, compId, layerId?}`. Panel reads the PNG, base64-encodes, returns `{base64, bytes, ...}`. Server packages as MCP `image` content block.
 - **Long batch** (`run_batch` >100 ops): JSX returns `{jobId, async:true, total}`. Panel drives `_continue_job` in chunks of 25 in the background, broadcasting `progress` events on WS. Server forwards WS progress as `notifications/progress` keyed by the request's `progressToken`.
-- **Server-resident** (`await_job`, `get_job`, `cancel_job`, `check_setup`, `setup_panel`): handled in `server.ts`; never forwarded to the panel (except `cancel_job`, which also sends `_cancel_job` to the bridge to set the JSX-side flag). They're still listed in `OpSchemas` so `tools/list` picks them up — membership in `SERVER_OPS` is what stops the forwarding.
+- **Server-resident** (`await_job`, `get_job`, `cancel_job`, `check_setup`, `setup_panel`, `log_issue`, `list_known_issues`, `mark_issue_reported`): handled in `server.ts`; never forwarded to the panel (except `cancel_job`, which also sends `_cancel_job` to the bridge to set the JSX-side flag). They're still listed in `OpSchemas` so `tools/list` picks them up — membership in `SERVER_OPS` is what stops the forwarding.
 - **Downsampled screenshots**: handled entirely in `vision.jsx`. `saveFrameToPng` *does* respect `CompItem.resolutionFactor` (measured: a 3840×2160 comp yields 1920×1080 at factor 2, 960×540 at factor 4), so `__saveFrameAt` sets the factor, renders, and restores it in a `finally`. That restore is not optional — a throw mid-render would otherwise leave the user's comp at reduced resolution. The panel reads the true dimensions out of the PNG's IHDR chunk rather than computing them, so reported size can never disagree with the image sent. An earlier version shelled out to `sips`; it was replaced because rendering smaller is faster than resampling and needs no external tool, which is what makes downsampling work on Windows.
 
 ## Conventions
@@ -110,6 +111,17 @@ Publishing: `npm publish -w @engine-room/after-effects-mcp` (the `prepack` hook 
 6. `run_batch` with 50 `create_solid_layer` ops, `transactional:true` → single undo step.
 7. `run_batch` with 600 ops → returns `{jobId}` (inline cutoff is 500). With `progressToken` set, `notifications/progress` fire ~20/sec. Without it, `await_job(jobId)` resolves with the final result.
 8. `run_jsx("app.project.activeItem.name")` → comp name. With deliberate error → structured `AeError` with line number.
+9. `log_issue` twice with the same title → one file, `occurrences: 2`, `previouslyLogged: true`. `mark_issue_reported` then `log_issue` again → still `reported: true` (a new sighting must not un-report an entry).
+
+## The issue journal
+
+`log_issue` is how one session hands a hard-won workaround to the next. Three properties matter, and all three are things it would be easy to get wrong:
+
+- **The title is the identity.** It is slugified into the filename, so re-logging under the same title extends the entry rather than adding a near-duplicate. Agents are told to `list_known_issues` first for exactly this reason.
+- **Reporting state belongs to the entry, not the sighting.** Re-logging a known problem preserves `reported`, `issueUrl` and `firstSeen`, and a `cause` worked out once survives a later sighting logged without one. Otherwise the user gets asked to report the same thing repeatedly, which is the fastest way to make them stop reading the offer.
+- **The files are meant to be hand-edited.** `parse()` is deliberately forgiving: missing keys, reflowed text and deleted headings degrade one entry instead of failing the whole journal. A file with no recognised headings keeps its text as the symptom rather than being read as empty.
+
+The user-facing half is the offer to report. It lives in three places by necessity, because not every client loads skills: the `log_issue` **tool description** carries the minimum (finish the work first, phrase it for a non-programmer, don't say "GitHub issue"), the **`after-effects` skill** carries the full protocol with an example, and **`/report-ae-issue`** carries the reporting flow. If you change the behaviour, change all three — plus the condensed command template in `cli/init.ts`, which is what non-plugin users get.
 
 ## Known fragile areas
 
@@ -130,7 +142,7 @@ Linux is impossible, not merely unimplemented — Adobe has never shipped AE for
 
 All `packages/jsx/*.jsx` is AE's own scripting API and is platform-neutral; never add platform branching there. Host differences are confined to `setup/platform.ts` (PlayerDebugMode via `defaults` vs `reg`, AE process via `pgrep` vs `tasklist`) and `cepExtensionsDir()` in `setup/paths.ts` (`~/Library/Application Support/...` vs `%APPDATA%\...`).
 
-CI (`.github/workflows/ci.yml`) builds and smoke-tests on macos-latest and windows-latest: server starts, ≥60 tools, `check_setup` resolves paths, scaffold writes files. It cannot exercise the CEP install — no AE on a runner — so the Windows install path is the least-proven part of the project. macOS is the daily-driven platform.
+CI (`.github/workflows/ci.yml`) builds and smoke-tests on macos-latest and windows-latest: server starts, ≥63 tools, `check_setup` resolves paths, scaffold writes files. It cannot exercise the CEP install — no AE on a runner — so the Windows install path is the least-proven part of the project. macOS is the daily-driven platform.
 
 ## Out of scope (v1)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 | `packages/mcp-server/src/tools/descriptions.ts` | All tool descriptions in one file — including the verbatim screenshot guidance. |
 | `packages/mcp-server/src/bridge/{httpClient,wsClient,discovery}.ts` | Bridge plumbing. |
 | `packages/mcp-server/src/jobs/manager.ts` | In-memory job table, `waitFor(jobId)` for the `await_job` tool. |
-| `packages/mcp-server/src/issues/journal.ts` | The cross-session issue journal at `~/.after-effects-mcp/issues/`. Backs `log_issue` / `list_known_issues` / `mark_issue_reported`. Home directory, not the project folder: the knowledge is about the tools, so it should follow the user across projects, and a home directory is untracked by construction. `AE_MCP_HOME` overrides the root (used by the CI check). |
+| `packages/mcp-server/src/issues/journal.ts` | The cross-session issue journal at `<project>/.ae-mcp/issues/`. Backs `log_issue` / `list_known_issues` / `mark_issue_reported`. The project folder is `process.cwd()`; a client that gives no usable one (Claude Desktop starts servers at `/`) falls back to `~/.after-effects-mcp`, reported as `scope: "home"` so the fallback is never silent. `AE_MCP_HOME` overrides the root (used by the CI check). |
 | `packages/mcp-server/src/setup/{check,install,paths}.ts` | Backs `check_setup` / `setup_panel`. Never touches the bridge — it exists for the case where the panel isn't installed yet. |
 | `packages/mcp-server/src/setup/platform.ts` | **The only place macOS and Windows diverge** (PlayerDebugMode storage, AE process detection). Plus `cepExtensionsDir()` in `paths.ts`. Keep platform branching here — do not scatter `process.platform` through the codebase. |
 | `scripts/lib/setup.mjs` | Loads the compiled setup module so the dev scripts (`doctor`, `install-panel`, `enable-debug`) reuse the same platform logic the MCP tools use instead of keeping a second copy. |
@@ -115,7 +115,9 @@ Publishing: `npm publish -w @engine-room/after-effects-mcp` (the `prepack` hook 
 
 ## The issue journal
 
-`log_issue` is how one session hands a hard-won workaround to the next. Three properties matter, and all three are things it would be easy to get wrong:
+`log_issue` is how one session hands a hard-won workaround to the next, in the folder the work happened in. Four properties matter, and all four are things it would be easy to get wrong:
+
+- **The folder ignores itself.** `ensureJournalDir` writes `.ae-mcp/.gitignore` containing `*` on first use. That is what keeps the journal untracked — not a rule in the project's `.gitignore`, which most of these folders do not have, and which the ones that do would have to remember to add.
 
 - **The title is the identity.** It is slugified into the filename, so re-logging under the same title extends the entry rather than adding a near-duplicate. Agents are told to `list_known_issues` first for exactly this reason.
 - **Reporting state belongs to the entry, not the sighting.** Re-logging a known problem preserves `reported`, `issueUrl` and `firstSeen`, and a `cause` worked out once survives a later sighting logged without one. Otherwise the user gets asked to report the same thing repeatedly, which is the fastest way to make them stop reading the offer.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,13 @@ A few notes on the ones that behave differently from the rest:
 ## When something goes wrong
 
 These tools have rough edges. When the AI hits one and works out a way around
-it, it writes the problem and the fix into a notebook at
-`~/.after-effects-mcp/issues/` — plain text files you can read or delete. The
-next session reads that notebook before guessing, so the same twenty minutes are
-never spent twice, in this project or any other.
+it, it writes the problem and the fix into a notebook in your project folder, at
+`.ae-mcp/issues/` — plain text files you can read or delete. The next session
+reads that notebook before guessing, so the same twenty minutes are never spent
+twice on the same project.
+
+The folder ignores itself, so it stays out of version control without you doing
+anything.
 
 If the problem looks like ours rather than yours, the AI will say so at the end
 of its reply and offer to pass it on. You can also start that yourself:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ It reinstalls the panel and tells you to restart After Effects. Ask it to check 
 | Raw (1) | `run_jsx` |
 | Jobs (3) | `await_job`, `get_job`, `cancel_job` |
 | Setup (2) | `check_setup`, `setup_panel` |
+| Issues (3) | `list_known_issues`, `log_issue`, `mark_issue_reported` |
 
 A few notes on the ones that behave differently from the rest:
 
@@ -101,6 +102,27 @@ A few notes on the ones that behave differently from the rest:
 - `run_batch` runs many operations in a single pass and counts as one undo step. Long batches stream progress.
 - `screenshot_frame` and `screenshot_layer` are for occasional checks, not for reviewing motion frame by frame. On large comps, `downsample: 2` renders at half resolution, which is faster and keeps the image small.
 - `run_jsx` runs arbitrary ExtendScript for anything the other tools do not cover.
+- `log_issue` and `list_known_issues` are the notebook described below.
+
+## When something goes wrong
+
+These tools have rough edges. When the AI hits one and works out a way around
+it, it writes the problem and the fix into a notebook at
+`~/.after-effects-mcp/issues/` — plain text files you can read or delete. The
+next session reads that notebook before guessing, so the same twenty minutes are
+never spent twice, in this project or any other.
+
+If the problem looks like ours rather than yours, the AI will say so at the end
+of its reply and offer to pass it on. You can also start that yourself:
+
+```
+/report-ae-issue
+```
+
+It writes the report, shows it to you, and only sends it once you say yes.
+Nothing about your own work — comp names, file paths, clients — goes into it.
+Sending needs the [GitHub CLI](https://cli.github.com); without it you get a
+prefilled link to click instead.
 
 ## Troubleshooting
 

--- a/packages/mcp-server/src/cli/init.ts
+++ b/packages/mcp-server/src/cli/init.ts
@@ -66,6 +66,46 @@ description: The visual and motion style for this project — palette, type, tim
   footage — always on a rounded chip", "keep total runtime under 8 seconds"._
 `;
 
+/**
+ * Condensed twin of `plugin/commands/report-ae-issue.md`, which is the canonical
+ * version. Users who install the plugin get that one; users who only ran `init`
+ * get this. They do not have to match word for word — both have to work on their
+ * own — but a change to the reporting flow belongs in both.
+ */
+const REPORT_COMMAND = `---
+description: Send a problem you hit with the After Effects tools to the people who maintain them
+argument-hint: "[what went wrong, in your own words]"
+---
+
+# Report a problem with the After Effects tools
+
+Assume the person you are helping is a motion designer, not a developer, and may
+never have used GitHub. Do the technical part for them.
+
+1. **Find what to report.** Call \`list_known_issues\` with \`status: "unreported"\`.
+   It returns what earlier sessions wrote down, plus \`repo\`, \`newIssueUrl\`,
+   \`serverVersion\` and \`platform\`. List the entries in plain sentences — not raw
+   titles — and ask which to send. If there is nothing recorded but \`$ARGUMENTS\`
+   describes a problem, ask what they were doing and what happened, then
+   \`log_issue\` it first. If there is nothing at all, say so and stop.
+
+2. **Draft it short.** Title: one concrete line. Body: **What happens** (the
+   failing call and exact error), **Why** if known, **Workaround**, and
+   **Environment** (\`after-effects-mcp <serverVersion> · <platform> · After
+   Effects 2026\`). Leave out their own work — comp names, file paths, client
+   names, anything about the video.
+
+3. **Show it and ask.** This posts publicly, so get a real yes.
+
+4. **Send it.** \`gh issue create --repo <repo> --title "..." --body "..."\`. If
+   \`gh\` is missing or not logged in, do not install it — build a prefilled link
+   instead by URL-encoding the title and body onto \`<newIssueUrl>\` as
+   \`?title=…&body=…\`, and tell them to open it and press the green button.
+
+5. **Close the loop.** On success call \`mark_issue_reported\` with the entry id
+   and URL, then give them the link. If they decline, leave the entry unreported.
+`;
+
 const CLAUDE_MD = `# {{NAME}}
 
 After Effects project folder. The tools drive After Effects directly from here.
@@ -82,6 +122,14 @@ After Effects project folder. The tools drive After Effects directly from here.
 The look of everything built here is defined in
 \`.claude/skills/house-style/SKILL.md\`. Edit that file to change the defaults —
 palette, type, timing, layout. It is read automatically.
+
+## When a tool misbehaves
+
+Check \`list_known_issues\` before guessing — an earlier session may already have
+solved it. When you work out a fix for something that cost real time and was the
+tool's fault rather than yours, record it with \`log_issue\` so the next session
+does not pay for it again, and offer at the end of your reply to pass it on.
+\`/report-ae-issue\` sends it to the maintainers.
 
 ## Conventions for this project
 
@@ -134,6 +182,7 @@ export function runInit(argv: string[]): number {
   const files: Array<[string, string]> = [
     ["CLAUDE.md", CLAUDE_MD.replace("{{NAME}}", name)],
     [path.join(".claude", "skills", "house-style", "SKILL.md"), HOUSE_STYLE],
+    [path.join(".claude", "commands", "report-ae-issue.md"), REPORT_COMMAND],
     [path.join("renders", ".gitkeep"), ""],
   ];
   if (parsed.withMcp) files.push([".mcp.json", MCP_JSON]);
@@ -161,6 +210,7 @@ export function runInit(argv: string[]): number {
     ``,
     `  CLAUDE.md                                what this project is`,
     `  .claude/skills/house-style/SKILL.md      your look — edit this first`,
+    `  .claude/commands/report-ae-issue.md      /report-ae-issue — tell the maintainers something broke`,
     `  renders/                                 exports land here`,
     ...(parsed.withMcp ? [`  .mcp.json                                connects your client to After Effects`] : []),
     ``,

--- a/packages/mcp-server/src/issues/journal.ts
+++ b/packages/mcp-server/src/issues/journal.ts
@@ -1,0 +1,295 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { packageVersion } from "../setup/paths.js";
+
+/**
+ * A journal of problems previous sessions hit with these tools, and the
+ * workarounds that got past them.
+ *
+ * The point is continuity between sessions: an agent that spends twenty minutes
+ * discovering that a spatial property wants exactly one ease entry should be the
+ * last one to spend it. The next session reads the entry instead.
+ *
+ * It lives in the user's home directory rather than in whatever project folder
+ * happens to be open, for two reasons: the knowledge is about the tools, not
+ * about one video, so it should follow the user across projects; and a home
+ * directory is untracked by construction — nothing here is ever committed by
+ * accident, and no .gitignore has to be maintained to keep it that way.
+ */
+
+/** Where reports go. Read by the reporting command, not hardcoded in it. */
+export const REPO = "Engine-Room-Games/after-effects-mcp";
+export const NEW_ISSUE_URL = `https://github.com/${REPO}/issues/new`;
+
+const SECTION_SYMPTOM = "What went wrong";
+const SECTION_CAUSE = "Why";
+const SECTION_WORKAROUND = "What worked";
+
+export interface IssueEntry {
+  id: string;
+  title: string;
+  /** Tool names involved, so a failing tool can be matched against the journal. */
+  tools: string[];
+  firstSeen: string;
+  lastSeen: string;
+  occurrences: number;
+  reported: boolean;
+  issueUrl?: string;
+  symptom: string;
+  cause?: string;
+  workaround: string;
+}
+
+export interface LogIssueInput {
+  title: string;
+  symptom: string;
+  workaround: string;
+  cause?: string;
+  tools?: string[];
+}
+
+export interface LogIssueResult {
+  id: string;
+  path: string;
+  occurrences: number;
+  /** True when an entry already existed — the agent hit a known problem. */
+  previouslyLogged: boolean;
+  /** Already sent to the maintainers: do not ask the user to report it again. */
+  reported: boolean;
+  issueUrl?: string;
+}
+
+export function journalDir(): string {
+  const override = process.env.AE_MCP_HOME?.trim();
+  const home = override && override.length > 0 ? override : path.join(os.homedir(), ".after-effects-mcp");
+  return path.join(home, "issues");
+}
+
+/**
+ * Titles become filenames, and ids arrive from model input, so this is also the
+ * only thing standing between `../../` in an id and a write outside the journal.
+ */
+export function slugify(text: string): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+    .replace(/-+$/g, "");
+  return slug.length > 0 ? slug : `issue-${Date.now()}`;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Frontmatter is line-oriented, so anything with a newline in it would break it. */
+function oneLine(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function entryPath(id: string): string {
+  const dir = path.resolve(journalDir());
+  const file = path.resolve(dir, `${id}.md`);
+  if (path.dirname(file) !== dir) throw new Error(`Invalid issue id: ${id}`);
+  return file;
+}
+
+export function render(entry: IssueEntry): string {
+  const lines = [
+    "---",
+    `id: ${entry.id}`,
+    `title: ${oneLine(entry.title)}`,
+    `tools: ${entry.tools.join(", ")}`,
+    `firstSeen: ${entry.firstSeen}`,
+    `lastSeen: ${entry.lastSeen}`,
+    `occurrences: ${entry.occurrences}`,
+    `reported: ${entry.reported}`,
+    `issueUrl: ${entry.issueUrl ?? ""}`,
+    "---",
+    "",
+    `## ${SECTION_SYMPTOM}`,
+    "",
+    entry.symptom.trim(),
+    "",
+  ];
+  if (entry.cause && entry.cause.trim().length > 0) {
+    lines.push(`## ${SECTION_CAUSE}`, "", entry.cause.trim(), "");
+  }
+  lines.push(`## ${SECTION_WORKAROUND}`, "", entry.workaround.trim(), "");
+  return lines.join("\n");
+}
+
+/**
+ * Split the body on the three headings this module writes, and only those. A
+ * workaround is often the one place a markdown heading legitimately appears —
+ * pasted output, a numbered write-up — and splitting on every `##` would tear
+ * the text it is there to preserve.
+ */
+function readSections(body: string): Map<string, string> {
+  const marks: Array<{ key: string; from: number; to: number }> = [];
+  for (const heading of [SECTION_SYMPTOM, SECTION_CAUSE, SECTION_WORKAROUND]) {
+    const m = new RegExp(`^##[ \\t]+${heading}[ \\t]*$`, "im").exec(body);
+    if (m) marks.push({ key: heading.toLowerCase(), from: m.index, to: m.index + m[0].length });
+  }
+  marks.sort((a, b) => a.from - b.from);
+
+  const sections = new Map<string, string>();
+  marks.forEach((mark, i) => {
+    const end = i + 1 < marks.length ? marks[i + 1]!.from : body.length;
+    sections.set(mark.key, body.slice(mark.to, end).trim());
+  });
+  return sections;
+}
+
+/**
+ * Deliberately forgiving: these files are meant to be readable and editable by
+ * hand, so a human who reflows one, drops a key or deletes a heading should get
+ * a degraded entry rather than a parse error that hides the whole journal.
+ */
+export function parse(text: string, fallbackId: string): IssueEntry {
+  const meta: Record<string, string> = {};
+  let body = text;
+
+  const fm = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/.exec(text);
+  if (fm) {
+    for (const line of fm[1]!.split(/\r?\n/)) {
+      const sep = line.indexOf(":");
+      if (sep <= 0) continue;
+      meta[line.slice(0, sep).trim()] = line.slice(sep + 1).trim();
+    }
+    body = text.slice(fm[0].length);
+  }
+
+  const sections = readSections(body);
+
+  const occurrences = Number.parseInt(meta.occurrences ?? "1", 10);
+  return {
+    id: meta.id || fallbackId,
+    title: meta.title || fallbackId.replace(/-/g, " "),
+    tools: (meta.tools ?? "")
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0),
+    firstSeen: meta.firstSeen || "",
+    lastSeen: meta.lastSeen || meta.firstSeen || "",
+    occurrences: Number.isFinite(occurrences) && occurrences > 0 ? occurrences : 1,
+    reported: meta.reported === "true",
+    issueUrl: meta.issueUrl && meta.issueUrl.length > 0 ? meta.issueUrl : undefined,
+    // A hand-edited file with no recognised headings still has its text kept,
+    // rather than being silently reduced to an empty entry.
+    symptom: sections.get(SECTION_SYMPTOM.toLowerCase()) ?? (sections.size === 0 ? body.trim() : ""),
+    cause: sections.get(SECTION_CAUSE.toLowerCase()) || undefined,
+    workaround: sections.get(SECTION_WORKAROUND.toLowerCase()) ?? "",
+  };
+}
+
+function readEntry(file: string): IssueEntry | null {
+  try {
+    return parse(fs.readFileSync(file, "utf8"), path.basename(file, ".md"));
+  } catch {
+    return null;
+  }
+}
+
+export function logIssue(input: LogIssueInput): LogIssueResult {
+  const id = slugify(input.title);
+  const file = entryPath(id);
+  const existing = fs.existsSync(file) ? readEntry(file) : null;
+
+  const entry: IssueEntry = {
+    id,
+    title: oneLine(input.title),
+    tools: input.tools ?? existing?.tools ?? [],
+    firstSeen: existing?.firstSeen || today(),
+    lastSeen: today(),
+    // Repeats are worth counting: an entry seen five times is the one most
+    // worth reporting, and the count is the only evidence of that.
+    occurrences: (existing?.occurrences ?? 0) + 1,
+    // Reporting state belongs to the entry, not to this sighting — a fresh
+    // description of a known problem must not un-report it.
+    reported: existing?.reported ?? false,
+    issueUrl: existing?.issueUrl,
+    symptom: input.symptom,
+    // A cause worked out once is not lost because a later sighting was logged
+    // without one.
+    cause: input.cause ?? existing?.cause,
+    workaround: input.workaround,
+  };
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, render(entry), "utf8");
+
+  return {
+    id,
+    path: file,
+    occurrences: entry.occurrences,
+    previouslyLogged: existing !== null,
+    reported: entry.reported,
+    issueUrl: entry.issueUrl,
+  };
+}
+
+export type IssueStatus = "all" | "unreported" | "reported";
+
+export interface IssueListing {
+  dir: string;
+  repo: string;
+  newIssueUrl: string;
+  serverVersion: string;
+  platform: string;
+  count: number;
+  issues: IssueEntry[];
+}
+
+export function listIssues(status: IssueStatus = "all", tool?: string): IssueListing {
+  const dir = journalDir();
+  let entries: IssueEntry[] = [];
+  try {
+    entries = fs
+      .readdirSync(dir)
+      .filter((f) => f.endsWith(".md"))
+      .map((f) => readEntry(path.join(dir, f)))
+      .filter((e): e is IssueEntry => e !== null);
+  } catch {
+    entries = []; // No journal yet is the normal state, not an error.
+  }
+
+  const wanted = tool?.trim().toLowerCase();
+  const filtered = entries.filter((e) => {
+    const byStatus = status === "all" ? true : status === "reported" ? e.reported : !e.reported;
+    if (!byStatus) return false;
+    if (!wanted) return true;
+    // The title is matched too: an entry logged before the `tools` field was
+    // filled in still names the tool it is about.
+    return e.tools.some((t) => t.toLowerCase() === wanted) || e.title.toLowerCase().includes(wanted);
+  });
+  // Most recent first, and among same-day entries the ones that keep recurring.
+  filtered.sort((a, b) => b.lastSeen.localeCompare(a.lastSeen) || b.occurrences - a.occurrences);
+
+  return {
+    dir,
+    repo: REPO,
+    newIssueUrl: NEW_ISSUE_URL,
+    serverVersion: packageVersion(),
+    platform: process.platform,
+    count: filtered.length,
+    issues: filtered,
+  };
+}
+
+export function markReported(id: string, url?: string): IssueEntry {
+  const file = entryPath(slugify(id));
+  const entry = fs.existsSync(file) ? readEntry(file) : null;
+  if (!entry) {
+    const known = listIssues("all").issues.map((e) => e.id);
+    throw new Error(
+      `No journal entry with id "${id}".` + (known.length > 0 ? ` Known ids: ${known.join(", ")}` : "")
+    );
+  }
+  entry.reported = true;
+  if (url) entry.issueUrl = oneLine(url);
+  fs.writeFileSync(file, render(entry), "utf8");
+  return entry;
+}

--- a/packages/mcp-server/src/issues/journal.ts
+++ b/packages/mcp-server/src/issues/journal.ts
@@ -11,11 +11,11 @@ import { packageVersion } from "../setup/paths.js";
  * discovering that a spatial property wants exactly one ease entry should be the
  * last one to spend it. The next session reads the entry instead.
  *
- * It lives in the user's home directory rather than in whatever project folder
- * happens to be open, for two reasons: the knowledge is about the tools, not
- * about one video, so it should follow the user across projects; and a home
- * directory is untracked by construction — nothing here is ever committed by
- * accident, and no .gitignore has to be maintained to keep it that way.
+ * It lives in `.ae-mcp/` inside the project folder, so it sits next to the work
+ * it came out of and travels with it. Untracked, but not by accident: the folder
+ * ignores itself (see `ensureJournalDir`) rather than relying on the project
+ * keeping a .gitignore rule, since most of these folders are not repositories at
+ * all and the ones that are should not carry these notes into a commit.
  */
 
 /** Where reports go. Read by the reporting command, not hardcoded in it. */
@@ -60,10 +60,54 @@ export interface LogIssueResult {
   issueUrl?: string;
 }
 
-export function journalDir(): string {
+/** Where the journal ended up — reported so the agent can always say where its notes live. */
+export type JournalScope = "project" | "home";
+
+/**
+ * The project folder is the working directory the client started this server in,
+ * which is what "the folder the user has open" means for every client that has
+ * such a concept.
+ *
+ * Some do not: Claude Desktop spawns servers from the filesystem root. Writing a
+ * project journal to `/` would be wrong even where it is permitted, so an
+ * unusable working directory falls back to the user's home rather than failing
+ * the tool. `list_known_issues` reports the scope it resolved to, so the fallback
+ * is visible rather than silent.
+ */
+export function journalRoot(): { dir: string; scope: JournalScope } {
   const override = process.env.AE_MCP_HOME?.trim();
-  const home = override && override.length > 0 ? override : path.join(os.homedir(), ".after-effects-mcp");
-  return path.join(home, "issues");
+  if (override && override.length > 0) return { dir: override, scope: "project" };
+
+  const cwd = process.cwd();
+  const unusable = cwd === path.parse(cwd).root || cwd === os.homedir();
+  if (!unusable) {
+    try {
+      fs.accessSync(cwd, fs.constants.W_OK);
+      return { dir: path.join(cwd, ".ae-mcp"), scope: "project" };
+    } catch {
+      // Read-only working directory — fall through.
+    }
+  }
+  return { dir: path.join(os.homedir(), ".after-effects-mcp"), scope: "home" };
+}
+
+export function journalDir(): string {
+  return path.join(journalRoot().dir, "issues");
+}
+
+/**
+ * Create the journal and make it invisible to git in one step. A `.gitignore`
+ * of `*` inside the folder ignores the folder's whole contents — including
+ * itself — without touching a rule the user maintains, and works the same in a
+ * repository, a folder that becomes one later, and one that never does.
+ */
+function ensureJournalDir(): string {
+  const { dir } = journalRoot();
+  const issues = path.join(dir, "issues");
+  fs.mkdirSync(issues, { recursive: true });
+  const ignore = path.join(dir, ".gitignore");
+  if (!fs.existsSync(ignore)) fs.writeFileSync(ignore, "*\n", "utf8");
+  return issues;
 }
 
 /**
@@ -218,7 +262,7 @@ export function logIssue(input: LogIssueInput): LogIssueResult {
     workaround: input.workaround,
   };
 
-  fs.mkdirSync(path.dirname(file), { recursive: true });
+  ensureJournalDir();
   fs.writeFileSync(file, render(entry), "utf8");
 
   return {
@@ -235,6 +279,8 @@ export type IssueStatus = "all" | "unreported" | "reported";
 
 export interface IssueListing {
   dir: string;
+  /** "project" for this folder's own journal; "home" when there was no usable working directory. */
+  scope: JournalScope;
   repo: string;
   newIssueUrl: string;
   serverVersion: string;
@@ -244,6 +290,7 @@ export interface IssueListing {
 }
 
 export function listIssues(status: IssueStatus = "all", tool?: string): IssueListing {
+  const { scope } = journalRoot();
   const dir = journalDir();
   let entries: IssueEntry[] = [];
   try {
@@ -270,6 +317,7 @@ export function listIssues(status: IssueStatus = "all", tool?: string): IssueLis
 
   return {
     dir,
+    scope,
     repo: REPO,
     newIssueUrl: NEW_ISSUE_URL,
     serverVersion: packageVersion(),

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -12,6 +12,7 @@ import { descriptions } from "./tools/descriptions.js";
 import { AeError, BridgeUnreachableError } from "./util/errors.js";
 import { checkSetup } from "./setup/check.js";
 import { installPanel } from "./setup/install.js";
+import { listIssues, logIssue, markReported } from "./issues/journal.js";
 import { imageContent } from "./util/pngImage.js";
 import { logger } from "./util/logger.js";
 import { z } from "zod";
@@ -24,8 +25,18 @@ const VISION_OPS = new Set(["screenshot_frame", "screenshot_layer"]);
 const ASYNC_OPS = new Set(["run_batch"]);
 // Jobs/await/etc. are handled in-server, not forwarded as-is. The setup ops
 // especially must never touch the bridge — they exist precisely for the case
-// where the panel is not installed yet.
-const SERVER_OPS = new Set(["await_job", "get_job", "cancel_job", "check_setup", "setup_panel"]);
+// where the panel is not installed yet, which is also when the issue journal is
+// most likely to be written to.
+const SERVER_OPS = new Set([
+  "await_job",
+  "get_job",
+  "cancel_job",
+  "check_setup",
+  "setup_panel",
+  "log_issue",
+  "list_known_issues",
+  "mark_issue_reported",
+]);
 
 // Schema for await_job/get_job/cancel_job (defined inline in shared/schemas.ts).
 const AwaitJobSchema = schemas.AwaitJob;
@@ -104,6 +115,19 @@ export function createServer() {
           // Re-run the diagnostic so the agent sees the resulting state rather
           // than having to guess whether the install was sufficient.
           return textResult({ ...installed, setup: await checkSetup() });
+        }
+        if (name === "log_issue") {
+          const a = schemas.LogIssue.parse(rawArgs);
+          return textResult(logIssue(a));
+        }
+        if (name === "list_known_issues") {
+          const a = schemas.ListKnownIssues.parse(rawArgs);
+          return textResult(listIssues(a.status ?? "all", a.tool));
+        }
+        if (name === "mark_issue_reported") {
+          const a = schemas.MarkIssueReported.parse(rawArgs);
+          const entry = markReported(a.id, a.url);
+          return textResult({ ok: true, id: entry.id, reported: true, issueUrl: entry.issueUrl });
         }
       } catch (e) {
         return errorResult((e as Error).message);

--- a/packages/mcp-server/src/setup/paths.ts
+++ b/packages/mcp-server/src/setup/paths.ts
@@ -30,6 +30,20 @@ function packageRoot(): string {
 }
 
 /**
+ * The version of the published package, read at runtime rather than compiled in
+ * so that it cannot drift from what the user actually installed. Used when a
+ * problem report needs to say which build hit it.
+ */
+export function packageVersion(): string {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot(), "package.json"), "utf8"));
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
  * The CEP panel lives in a different place depending on how the server was
  * obtained: inside the published tarball it is vendored at `<package>/panel`,
  * while in the git checkout it is a sibling workspace.

--- a/packages/mcp-server/src/tools/descriptions.ts
+++ b/packages/mcp-server/src/tools/descriptions.ts
@@ -95,4 +95,12 @@ export const descriptions: Record<string, string> = {
   // ---------- setup ----------
   check_setup: "Diagnose the After Effects connection: panel installed, up to date, Adobe debug preference on, AE running, bridge answering. Read-only and safe to call any time. Call this FIRST whenever another tool reports it cannot reach After Effects, then relay `nextSteps` to the user in plain language.",
   setup_panel: "Install or refresh the After Effects panel and enable the Adobe preference AE needs to load it. Run this when check_setup reports the panel is missing or out of date. It writes to the user's Adobe CEP extensions folder and sets a user-level Adobe preference — tell the user what it will do before calling it. Afterwards, AE must be restarted; if the preference was newly enabled, a one-time Mac reboot may also be needed.",
+
+  // ---------- issue journal ----------
+  list_known_issues:
+    "Problems earlier sessions hit with these tools, with the workarounds that worked. Read it when a tool fails in a way you don't immediately understand — pass `tool` to narrow it to that one — and before nontrivial work. It can save you rediscovering a fix that already cost someone an hour. Also returns the repo and server version needed to report one.",
+  log_issue:
+    "Record a problem you hit and the workaround that got past it, so the next session doesn't rediscover it. Log only what cost real effort and will recur: a tool failing for a non-obvious reason, an argument shape the schema didn't imply, AE behaving unlike the docs. Not your own typos, not one-off user mistakes. Call list_known_issues first and reuse the same title to extend an existing entry rather than duplicating it. If the result comes back with reported:false, then AFTER you have finished the actual work, close your reply by telling the user in plain language that something took much longer than it should have and offering to pass it to the people who maintain this tool — phrase it for a motion designer, in terms of what actually happened, and don't say 'GitHub issue' or 'bug report' unless they say it first.",
+  mark_issue_reported:
+    "Record that a journal entry has been sent to the maintainers, with the resulting URL. Call it only once the issue really exists, so later sessions don't ask the user to report the same thing twice.",
 };

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -429,6 +429,29 @@ export const SetupPanel = z.object({
     .describe("Replace an existing symlinked (development) install with a copy. Default false."),
 }).strict();
 
+// ---------- issue journal (handled in the MCP server, never forwarded to the panel) ----------
+export const LogIssue = z
+  .object({
+    title: z.string().min(3).describe("One line naming the problem, specific enough to recognise again. Becomes the entry's id."),
+    symptom: z.string().min(3).describe("What went wrong, including the exact error text and the call that produced it."),
+    workaround: z.string().min(3).describe("What actually worked — concrete enough for the next session to apply without rediscovering it."),
+    cause: z.string().optional().describe("Why it happens, if you worked it out."),
+    tools: z.array(z.string()).optional().describe("Tool names involved, e.g. ['set_temporal_ease']."),
+  })
+  .strict();
+export const ListKnownIssues = z
+  .object({
+    status: z.enum(["all", "unreported", "reported"]).default("all").optional(),
+    tool: z.string().optional().describe("Only entries about this tool, e.g. 'set_temporal_ease'. Omit for everything."),
+  })
+  .strict();
+export const MarkIssueReported = z
+  .object({
+    id: z.string().describe("The entry id returned by log_issue or list_known_issues."),
+    url: z.string().optional().describe("Link to the issue that was opened."),
+  })
+  .strict();
+
 export const AwaitJob = z.object({ jobId: z.string(), timeoutMs: z.number().int().positive().default(600_000).optional() });
 export const GetJob = z.object({ jobId: z.string() });
 export const CancelJob = z.object({ jobId: z.string() });
@@ -514,6 +537,10 @@ export const OpSchemas = {
   // setup
   check_setup: CheckSetup,
   setup_panel: SetupPanel,
+  // issue journal
+  log_issue: LogIssue,
+  list_known_issues: ListKnownIssues,
+  mark_issue_reported: MarkIssueReported,
 } as const;
 
 export type OpName = keyof typeof OpSchemas;

--- a/plugin/commands/report-ae-issue.md
+++ b/plugin/commands/report-ae-issue.md
@@ -1,0 +1,86 @@
+---
+description: Send a problem you hit with the After Effects tools to the people who maintain them
+argument-hint: "[what went wrong, in your own words]"
+allowed-tools: Bash(gh issue create:*), Bash(gh auth status:*), Bash(gh --version)
+---
+
+# Report a problem with the After Effects tools
+
+The user wants to tell the maintainers about something that did not work. They are
+most likely a motion designer, not a developer: they may never have seen GitHub,
+and they should not have to. Do the technical part yourself and only ask them
+things they can actually answer.
+
+`$ARGUMENTS` is what they typed, if anything.
+
+## 1. Find out what to report
+
+Call `list_known_issues` with `status: "unreported"`. It returns entries earlier
+sessions wrote down, plus `repo`, `newIssueUrl`, `serverVersion` and `platform`.
+
+- **Entries exist** — show them as a short numbered list, one plain sentence each
+  ("Text layers ended up in the wrong place when a font was missing"), not the
+  raw titles. Ask which to send; offer "all of them" as an option.
+- **No entries, but `$ARGUMENTS` describes something** — work from that. Ask what
+  they were trying to do and what happened instead, then `log_issue` it so it is
+  recorded before you send it.
+- **Nothing either way** — say there is nothing recorded to send, and that you
+  will write things down as you hit them from now on. Stop there.
+
+## 2. Draft it
+
+Short. A maintainer should understand the problem in fifteen seconds.
+
+**Title:** one line, concrete. `set_temporal_ease fails on Position with "Value
+array does not have 1 elements"` — not `Keyframe bug`.
+
+**Body:** four short sections, a couple of sentences each.
+
+```markdown
+**What happens**
+<the failing call and the exact error, or the wrong result>
+
+**Why** (if known)
+<one line — omit this section entirely if unknown>
+
+**Workaround**
+<what got past it>
+
+**Environment**
+after-effects-mcp <serverVersion> · <platform> · After Effects 2026
+```
+
+Include the failing call and error text verbatim — that is the part that makes it
+fixable. Leave out the user's own content: comp and layer names from their
+project, file paths, client names, anything about the video they are making. If a
+detail like that is load-bearing, replace it with a placeholder.
+
+## 3. Show it and get a yes
+
+Show the finished title and body and ask whether to send it. This posts publicly
+to a repository under their name if `gh` is authenticated, so it needs a real
+answer, not an assumption. If they want to change the wording, change it.
+
+## 4. Send it
+
+Try `gh` first:
+
+```bash
+gh issue create --repo <repo> --title "<title>" --body "<body>"
+```
+
+If `gh` is missing or not authenticated, do not try to install or configure it.
+Build a prefilled link instead — URL-encode the title and body onto
+`<newIssueUrl>` as `?title=…&body=…` — and give it to them with one line of
+instruction: open this, it will already be filled in, press the green button. A
+GitHub account is needed to press it; if they do not have one, say so plainly and
+offer to write the text out for them to send another way.
+
+## 5. Close the loop
+
+On success, call `mark_issue_reported` with the entry `id` and the URL, so no
+later session asks them to report the same thing twice. Then tell them where it
+went, in one sentence, with the link.
+
+If they decline, leave the entry alone — it stays unreported and can be offered
+again another day. Do not mark it.

--- a/plugin/skills/after-effects/SKILL.md
+++ b/plugin/skills/after-effects/SKILL.md
@@ -94,6 +94,51 @@ For a custom path, use `{type: "path", vertices: [[x,y], …], closed: true}`. T
 
 Two warnings: ExtendScript is **single-threaded**, so a long synchronous loop freezes the user's AE UI; and returned objects are flattened, so return a string you have assembled yourself rather than a nested object.
 
+## When something costs you real time
+
+These tools have rough edges, and the same ones catch every session. Two tools
+exist so that each one is only paid for once.
+
+**`list_known_issues`** — what earlier sessions hit and how they got past it.
+Read it when a tool fails in a way you do not immediately understand, before you
+start guessing. The answer is often already there.
+
+**`log_issue`** — write down what you worked out, the moment you work it out.
+
+Log something when all three are true: it cost real effort, it was the tool's
+fault rather than yours, and the next session would hit it too. A schema that
+accepts an argument AE then rejects, an error message that names the wrong
+thing, a property whose real name is nothing like its display name. Not your own
+typos. Not "I forgot the layer was 3D".
+
+Write the entry for someone who has not seen the failure: the exact error text,
+the call that produced it, and a workaround concrete enough to apply directly.
+Reuse the existing title when you are extending an entry — that keeps one good
+record instead of five thin ones.
+
+### Then offer to pass it on
+
+If `log_issue` comes back with `reported: false`, mention it to the user — but
+finish the actual work first, and put it at the very end, after you have told
+them what you built. It is a footnote, not the headline.
+
+Say it the way you would to a colleague who does not write code. What you were
+trying to do, that it fought back, that you got there anyway, and that you can
+send it to the people who maintain the tool so the next person does not lose the
+same time. Something like:
+
+> Done — the lower third is in. One thing worth mentioning: getting the ease
+> onto that position keyframe took a lot longer than it should have, because the
+> tool kept rejecting a value it had just asked for. I found a way around it and
+> made a note. Want me to send it to the people who maintain this so they can
+> fix it properly?
+
+Do not say "GitHub issue", "file a bug" or "open a ticket" unless they say it
+first. If they say yes, run `/report-ae-issue` — it handles the rest. If they say
+no, drop it; the note stays and can be offered again another time.
+
+Never claim you have reported something you have not.
+
 ## When something is not connected
 
 If a tool reports it cannot reach After Effects, call `check_setup` and relay its `nextSteps` to the user in plain language. Do not try to diagnose CEP by hand.


### PR DESCRIPTION
Rough edges in these tools currently cost every session the same time, because nothing an agent works out survives the end of that session. This adds a journal that carries workarounds forward, and a way for the user to send the underlying problem back here without needing to know what a GitHub issue is.

## The journal

Three server-resident tools (`SERVER_OPS`, never forwarded to the panel):

| Tool | Purpose |
|---|---|
| `log_issue` | Write the problem, the workaround, and optionally the cause |
| `list_known_issues` | Read them back; `tool` narrows to one tool, `status` to unreported/reported |
| `mark_issue_reported` | Record that one has been sent, with its URL |

Entries are markdown files with small frontmatter, one per problem, in `.ae-mcp/issues/` inside the project folder — next to the work they came out of, and travelling with it.

Four behaviours are deliberate, and all four are easy to get wrong:

- **The folder ignores itself.** `.ae-mcp/.gitignore` containing `*` is written on first use, so the journal is invisible to git without the project carrying a rule for it. Most of these folders are not repositories; the ones that are should not carry these notes into a commit.
- **The title is the identity.** It slugifies to the filename, so re-logging under the same title extends the entry instead of adding a near-duplicate.
- **Reporting state belongs to the entry, not the sighting.** A new sighting preserves `reported`, `issueUrl` and `firstSeen`, and a cause worked out once survives a later sighting logged without one. Otherwise the user gets asked to report the same thing repeatedly, which is the fastest way to make them stop reading the offer.
- **The files are meant to be hand-edited.** Parsing is forgiving — missing keys, reflowed text and deleted headings degrade one entry rather than failing the journal — and only splits on the three headings it writes, so a workaround containing a markdown heading survives the round trip.

The project folder is `process.cwd()`, which is what "the folder the user has open" means for every client that has such a concept. Claude Desktop does not — it starts servers at `/` — so an unusable working directory falls back to `~/.after-effects-mcp` and reports `scope: "home"`, making the fallback visible rather than silent. `AE_MCP_HOME` overrides the root.

## Telling the user

After logging something unreported, the agent finishes the actual work first, then closes with an offer in the words a motion designer would use:

> Done — the lower third is in. One thing worth mentioning: getting the ease onto that position keyframe took a lot longer than it should have, because the tool kept rejecting a value it had just asked for. I found a way around it and made a note. Want me to send it to the people who maintain this so they can fix it properly?

Not "file a GitHub issue", unless they say it first.

`/report-ae-issue` handles the rest: it drafts a short report (what happens, why if known, workaround, environment), leaves out the user's own work — comp names, file paths, clients — shows it, and sends it only on an explicit yes. `gh issue create` when the CLI is there, a prefilled `issues/new?title=…&body=…` link to click when it isn't. On success it calls `mark_issue_reported` so no later session asks twice.

That behaviour is stated in three places because not every MCP client loads skills: the `log_issue` description carries the minimum, the `after-effects` skill carries the full protocol, and the command carries the reporting flow. Non-plugin users get a condensed command scaffolded by `init`. CLAUDE.md notes that a change to one belongs in all of them.

## Verification

Run locally, all passing:

- 63 tools over real JSON-RPC; the three new ones called end to end from a project working directory, including invalid args and a traversal-shaped id
- Two sibling project folders keep separate journals; `git status` in one is clean while `--ignored` shows `!! .ae-mcp/`; a server started at `/` resolves to `scope: "home"`
- Round trip of a workaround containing a `##` heading; a hand-mangled file degrades to one entry rather than a dead journal; the tool filter; `logIssue` twice keeping one file at `occurrences: 2` and staying reported
- Same against the packed tarball installed into an empty directory — the published layout resolves its own version correctly
- `init` scaffolds the command; `sync-version --check` clean

CI gains a journal round-trip step (the one piece of state this server owns, and it has to survive a Windows path), asserts the folder ignores itself and that the scaffolded command exists, and the tool floor moves 60 → 63.

Not done, and worth a follow-up if you want it: seeding a new journal with the quirks already listed under "Known fragile areas" in CLAUDE.md, so the first session in a new folder benefits before anyone has hit anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)