### PR TITLE
fix(deps): raise ws floor to ^8.21.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "engine-room-ae-mcp-workspace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "engine-room-ae-mcp-workspace",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "workspaces": [
         "packages/shared",
         "packages/mcp-server",
@@ -1729,9 +1729,9 @@
     },
     "packages/ae-panel": {
       "name": "@engineroom/ae-panel",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
-        "ws": "^8.18.0"
+        "ws": "^8.21.3"
       }
     },
     "packages/mcp-server": {
@@ -1744,7 +1744,7 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
-        "ws": "^8.18.0",
+        "ws": "^8.21.3",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -1764,7 +1764,7 @@
     },
     "packages/shared": {
       "name": "@engineroom/shared",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "zod": "^3.23.8"
       },

--- a/packages/ae-panel/package.json
+++ b/packages/ae-panel/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Invisible CEP extension hosting an HTTP+WS bridge inside After Effects.",
   "dependencies": {
-    "ws": "^8.18.0"
+    "ws": "^8.21.3"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
-    "ws": "^8.18.0",
+    "ws": "^8.21.3",
     "zod": "^3.23.8",
     "zod-to-json-schema": "^3.23.5"
   },


### PR DESCRIPTION
Supersedes #1.

Dependabot's #1 wanted `ws` at 8.21.1. Our lock has been on **8.21.3** since the 0.1.1 lockfile refresh, so merging it would have walked the lock *backwards* — but it was right about the declared range, which is still `^8.18.0` in both `packages/mcp-server` and `packages/ae-panel`.

That range is the part that actually ships. npm ignores a dependency's lockfile, so a consumer of `@engine-room/after-effects-mcp` resolves `ws` from `^8.18.0`, and `setup_panel` re-vendors that resolved copy into the CEP extension — where it backs the WebSocket server listening on `127.0.0.1:7777` inside After Effects.

Advisories against the old floor:

| Severity | Advisory | Affects |
|---|---|---|
| High | Memory exhaustion DoS from tiny fragments and data chunks | `>=8.0.0 <8.21.0` |
| Moderate | Uninitialized memory disclosure | `>=8.0.0 <8.20.1` |

The listener is localhost-only, so this is hardening rather than an open hole — but the floor costs nothing to raise.

**Lock is unchanged at 8.21.3**; only the two declared ranges move. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)