### PR TITLE
chore(node): move the floor to 22 and test both live LTS lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
+        # Both LTS lines that are still supported. 20 went EOL 2026-04-30;
+        # release.yml builds on 24, so 24 must stay in here.
+        node: ["22", "24"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ${{ matrix.node }}
 
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "packages/ae-panel"
       ],
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@engine-room/after-effects-mcp": {
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1753,13 +1753,13 @@
       },
       "devDependencies": {
         "@engineroom/shared": "*",
-        "@types/node": "^20.14.0",
+        "@types/node": "^22",
         "@types/ws": "^8.5.13",
         "esbuild": "^0.28.2",
         "typescript": "^5.6.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "pack:check": "npm run build && npm pack -w @engine-room/after-effects-mcp --dry-run"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -43,7 +43,7 @@
     "win32"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@engineroom/shared": "*",
-    "@types/node": "^20.14.0",
+    "@types/node": "^22",
     "@types/ws": "^8.5.13",
     "esbuild": "^0.28.2",
     "typescript": "^5.6.0"


### PR DESCRIPTION
Node 20 went **EOL on 2026-04-30**. Until this PR, the repo had three different answers to "which Node do we support":

| Where | Was | Now |
|---|---|---|
| `engines` (root + mcp-server) | `>=20` — EOL | `>=22` |
| `ci.yml` | builds on `20` only | matrix `22` + `24` |
| `release.yml` | builds on `24` | `24` (unchanged, now covered by CI) |
| `@types/node` | `^20.14.0` | `^22` |

Every green CI check was validating a runtime nobody should be running, while the artifact users actually install was built on 24 — a version CI never touched.

**Why 22 and not 24:** Node 22 is Maintenance LTS until 2027-04-30, so a `>=22` floor locks out nobody who is on a supported runtime. Node 24 is Active LTS until 2028-04-30 and is what `release.yml` builds with, so it has to be in the matrix regardless. CI goes from 2 jobs to 4.

`@types/node` follows the floor rather than the ceiling, so the types describe the oldest runtime we claim to support.

Verified locally against `@types/node` 22.20.1: `npm run build` passes, `sync-version --check` agrees on 0.1.2, server starts and lists 63 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)