### PR TITLE
fix(panel): resolve the extension path CEP hands back on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
       - name: Panel version mismatches are diagnosed correctly
         run: node tests/unit/panel-version.mjs
 
+      # No AE on a runner means nothing else here loads the panel's client code,
+      # and the Windows form of this bug reads as a missing bundle.jsx.
+      - name: Panel resolves the extension path CEP hands it
+        run: node tests/unit/panel-paths.mjs
+
       - name: check_setup resolves platform paths without throwing
         shell: bash
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,6 +286,7 @@ The user-facing half is the offer to report. It now lives in exactly two places:
 - **Bare Mach-O binaries cannot be stapled.** `xcrun stapler` only writes tickets into bundle formats (.app/.pkg/.dmg). The release notarizes the *zip* and lets Gatekeeper verify online on first launch. Do not add a `stapler staple` call expecting it to work.
 - **The hardened runtime blocks JIT.** Bun embeds JavaScriptCore, so `scripts/entitlements.plist` must grant `allow-jit` and `allow-unsigned-executable-memory`. Without them the binary signs and verifies fine and then refuses to launch — on someone else's machine, not yours.
 - **Generated files under `plugin/` will be overwritten.** `plugin/skills/**` and `plugin/commands/**` come from `src/{guides,prompts}/*.md`. Hand-edits survive until the next `npm run build`. CI runs `build-guides.mjs --check` to catch this at review time rather than in a release.
+- **CEP returns a file URL, not a path.** `getSystemPath` gives `file:///C:/Users/…` on Windows, so stripping only the scheme leaves `/C:/…`; `path.join` then reads it as root-relative and produces `\C:\…\bundle.jsx`, and the panel reports the bundle missing while it sits at that exact location. `client/csinterface.js` strips the slash before a drive letter — do that there, not at call sites, since it is the one place a URL becomes a native path. `tests/unit/panel-paths.mjs` covers it; there is no AE on a runner, so nothing else does.
 
 ## Platform notes
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "install:panel": "node scripts/install-panel.mjs",
     "uninstall:panel": "node scripts/uninstall-panel.mjs",
     "doctor": "node scripts/doctor.mjs",
-    "test": "node tests/unit/panel-version.mjs",
+    "test": "node tests/unit/panel-version.mjs && node tests/unit/panel-paths.mjs",
     "new:project": "node packages/mcp-server/dist/index.js init",
     "start": "node packages/mcp-server/dist/index.js",
     "inspect": "npx @modelcontextprotocol/inspector node packages/mcp-server/dist/index.js",

--- a/packages/ae-panel/client/csinterface.js
+++ b/packages/ae-panel/client/csinterface.js
@@ -11,6 +11,13 @@ CSInterface.prototype.evalScript = function (script, callback) {
 CSInterface.prototype.getSystemPath = function (pathType) {
   var path = window.__adobe_cep__.getSystemPath(pathType);
   if (path && path.indexOf("file://") === 0) path = decodeURIComponent(path.substring(7));
+  // CEP hands back a file URL, so on Windows the drive letter arrives still
+  // carrying the URL's leading slash: /C:/Users/... Node reads that as
+  // root-relative — path.join turns it into \C:\...\jsx\bundle.jsx, which no
+  // fs call can open, and the panel reports the bundle missing when it is
+  // sitting right there. Strip it here rather than at each call site: this is
+  // the one place a URL becomes a native path.
+  if (path) path = path.replace(/^\/([A-Za-z]:)/, "$1");
   return path;
 };
 

--- a/tests/unit/panel-paths.mjs
+++ b/tests/unit/panel-paths.mjs
@@ -1,0 +1,58 @@
+// getSystemPath's URL-to-native-path conversion.
+//
+// Worth a test of its own because the only failure it has ever produced looks
+// like a missing file: CEP returns a file URL, and on Windows the drive letter
+// keeps the URL's leading slash, so path.join yields \C:\...\bundle.jsx and the
+// panel says bundle.jsx is not there while it sits at that exact location.
+// There is no AE on a CI runner to catch it, so the conversion is checked here.
+//
+//   node tests/unit/panel-paths.mjs
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const source = fs.readFileSync(
+  path.join(root, "packages", "ae-panel", "client", "csinterface.js"),
+  "utf8",
+);
+
+// The panel's csinterface.js is a plain browser script, not a module: run it in
+// a context holding a stubbed CEP host and read the globals back out.
+function loadWith(raw) {
+  const context = { window: { __adobe_cep__: { getSystemPath: () => raw } } };
+  vm.runInNewContext(source, context);
+  return new context.CSInterface().getSystemPath(context.SystemPath.EXTENSION);
+}
+
+let passed = 0;
+function check(name, actual, expected) {
+  assert.equal(actual, expected, `${name}: expected "${expected}", got "${actual}"`);
+  passed++;
+}
+
+const WIN_EXT = "C:/Users/rougt/AppData/Roaming/Adobe/CEP/extensions/games.engine-room.ae-mcp";
+const MAC_EXT = "/Users/migs/Library/Application Support/Adobe/CEP/extensions/games.engine-room.ae-mcp";
+
+// The reported bug: file:/// leaves /C: behind once the scheme is stripped.
+check("windows file url", loadWith("file:///" + WIN_EXT), WIN_EXT);
+// Some CEP builds hand back the slashed path with no scheme at all.
+check("windows bare path", loadWith("/" + WIN_EXT), WIN_EXT);
+// Already native: nothing to strip.
+check("windows native path", loadWith("C:\\Users\\rougt\\AppData"), "C:\\Users\\rougt\\AppData");
+
+// macOS paths start with a slash that is part of the path. Stripping it there
+// would break the platform that currently works.
+check("mac file url", loadWith("file://" + MAC_EXT.replace(/ /g, "%20")), MAC_EXT);
+check("mac bare path", loadWith(MAC_EXT), MAC_EXT);
+
+// What the panel actually does with the result, on the platform that broke.
+const bundle = path.win32.join(loadWith("file:///" + WIN_EXT), "jsx", "bundle.jsx");
+assert.ok(path.win32.isAbsolute(bundle), `not absolute on Windows: ${bundle}`);
+assert.doesNotMatch(bundle, /^[\\/]/, `drive letter still behind a slash: ${bundle}`);
+passed += 2;
+
+console.log(`panel-paths: ${passed} assertions passed`);


### PR DESCRIPTION
Fixes #17.

## The bug

On Windows the panel refused to start, logging:

```
bundle.jsx not found at \C:\Users\rougt\AppData\Roaming\Adobe\CEP\extensions\
games.engine-room.ae-mcp\jsx\bundle.jsx — run `npm run build:jsx`
```

The file was sitting at exactly that location. Note the leading backslash before `C:`.

CEP's `getSystemPath` returns a **file URL**, not a path: `file:///C:/Users/…` on Windows. Our minimal `csinterface.js` stripped the seven characters of `file://` and stopped, leaving `/C:/Users/…`. Node's `path.join` reads a leading slash as root-relative and yields `\C:\…\jsx\bundle.jsx`, which no `fs` call can open. On macOS the same strip is correct, because there the leading slash really is part of the path — which is why only Windows users hit this.

## The fix

One line in `client/csinterface.js`, stripping the slash that precedes a drive letter. That layer, not the call site in `main.js` as the report suggested, because it is the single place a URL becomes a native path — `main.js:45` is the only caller today, but the next one would inherit the same bug.

## Test

`tests/unit/panel-paths.mjs` runs the panel's browser script in a `vm` against a stubbed CEP host and checks both platforms' path shapes, including that `path.win32.join` produces something absolute. Verified to fail with the fix reverted, reproducing the reported string exactly. Wired into `npm test` and CI — there is no AE on a runner, so nothing else exercises the panel's client code, and this class of bug is invisible until someone launches AE on Windows.

Not verified on a Windows AE install (no machine here); the reporter confirmed the equivalent one-liner works against their installed panel.