### PR TITLE
feat(server): serialize AE-writing calls behind one mutex

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,17 @@ jobs:
           node tests/unit/svg-import.mjs
           node tests/unit/bundle-determinism.mjs
 
+      # Concurrency is invisible when it breaks: a queue that lets two writes
+      # overlap looks identical to one that does not until an undo group is
+      # corrupted in someone's real project. The second file drives the real
+      # server over an in-memory transport against a stub bridge on an
+      # ephemeral port, and also fails the build when an op in OpSchemas has
+      # not been classified in OpMutation.
+      - name: Writes are serialized and every op is classified
+        run: |
+          node tests/unit/write-queue.mjs
+          node tests/unit/write-queue-server.mjs
+
       - name: check_setup resolves platform paths without throwing
         shell: bash
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ ExtendScript inside AE  (bundle.jsx = concat of packages/jsx/*.jsx)
 After Effects
 ```
 
-The MCP server is stateless except for an in-memory `JobManager`. The panel is the *only* thing that talks to AE; it holds a Promise-chain mutex around `evalScript` because ExtendScript is single-threaded and concurrent calls would interleave.
+The MCP server is stateless except for an in-memory `JobManager` and the write queue. The panel is the *only* thing that talks to AE; it holds a Promise-chain mutex around `evalScript` because ExtendScript is single-threaded and concurrent calls would interleave. That mutex is necessary and not sufficient — see "Serializing writes" below.
 
 ## Source layout
 
@@ -59,6 +59,7 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 | `packages/mcp-server/src/server.ts` | Tool registry, vision/async-envelope branching, error mapping. |
 | `packages/mcp-server/src/tools/descriptions.ts` | All tool descriptions in one file — including the verbatim screenshot guidance. |
 | `packages/mcp-server/src/bridge/{httpClient,wsClient,discovery}.ts` | Bridge plumbing. |
+| `packages/mcp-server/src/bridge/writeQueue.ts` | The one-writer-at-a-time mutex, and `extendUntil` — the lease that outlives its own call so a long `run_batch` keeps the lock while the panel drives it. Classification comes from `OpMutation` in `schemas.ts`. |
 | `packages/mcp-server/src/jobs/manager.ts` | In-memory job table, `waitFor(jobId)` for the `await_job` tool. |
 | `packages/mcp-server/src/issues/journal.ts` | The cross-session issue journal at `<project>/.ae-mcp/issues/`. Backs `log_issue` / `list_known_issues` / `mark_issue_reported`. The project folder is `process.cwd()`; a client that gives no usable one (Claude Desktop starts servers at `/`) falls back to `~/.after-effects-mcp`, reported as `scope: "home"` so the fallback is never silent. `AE_MCP_HOME` overrides the root (used by the CI check). |
 | `packages/mcp-server/src/setup/{check,install,paths}.ts` | Backs `check_setup` / `setup_panel`. Never touches the bridge — it exists for the case where the panel isn't installed yet. |
@@ -82,13 +83,14 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 
 ## The op pipeline (in detail)
 
-Adding a new op = touching five places. In order:
+Adding a new op = touching six places. In order:
 
 1. **Schema** — `packages/shared/src/schemas.ts`: add zod schema and an entry in `OpSchemas`.
-2. **ExtendScript handler** — add to the matching module in `packages/jsx/` as `OPS.your_op = function(args){ ... }`. Use `noUndo(fn)` for read-only ops (skips the undo group wrapper).
-3. **Description** — `packages/mcp-server/src/tools/descriptions.ts`: add an entry keyed by op name. Write it for an LLM agent reading the tool list cold.
-4. **Build** — `npm run build` rebuilds TS and concatenates the .jsx bundle.
-5. **Reload in AE** (optional, dev only) — `curl -X POST http://127.0.0.1:7777/reload-jsx` re-`$.evalFile`s the bundle without restarting AE.
+2. **Classification** — the `OpMutation` table at the bottom of the same file: `"write"`, `"read"` or `"server"`. `tests/unit/write-queue.mjs` fails the build if you skip it, on purpose — see "Serializing writes".
+3. **ExtendScript handler** — add to the matching module in `packages/jsx/` as `OPS.your_op = function(args){ ... }`. Use `noUndo(fn)` for read-only ops (skips the undo group wrapper).
+4. **Description** — `packages/mcp-server/src/tools/descriptions.ts`: add an entry keyed by op name. Write it for an LLM agent reading the tool list cold.
+5. **Build** — `npm run build` rebuilds TS and concatenates the .jsx bundle.
+6. **Reload in AE** (optional, dev only) — `curl -X POST http://127.0.0.1:7777/reload-jsx` re-`$.evalFile`s the bundle without restarting AE.
 
 The `server.ts` tool registration loop reads `OpSchemas`, so no MCP-side wiring is needed unless the op needs special return packaging (vision = image content, run_batch = async envelope, jobs/* = server-resident).
 
@@ -99,6 +101,79 @@ The `server.ts` tool registration loop reads `OpSchemas`, so no MCP-side wiring 
 - **Server-resident** (`await_job`, `get_job`, `cancel_job`, `check_setup`, `setup_panel`, `init_project`, `ae_guide`, `log_issue`, `list_known_issues`, `mark_issue_reported`): handled in `server.ts`; never forwarded to the panel (except `cancel_job`, which also sends `_cancel_job` to the bridge to set the JSX-side flag). They're still listed in `OpSchemas` so `tools/list` picks them up — membership in `SERVER_OPS` is what stops the forwarding.
 - **Prose** (`ae_guide`): returns the markdown as a bare text content block rather than through `textResult()`. JSON-stringifying it would hand the model a wall of `\n`.
 - **Downsampled screenshots**: handled entirely in `vision.jsx`. `saveFrameToPng` *does* respect `CompItem.resolutionFactor` (measured: a 3840×2160 comp yields 1920×1080 at factor 2, 960×540 at factor 4), so `__saveFrameAt` sets the factor, renders, and restores it in a `finally`. That restore is not optional — a throw mid-render would otherwise leave the user's comp at reduced resolution. The panel reads the true dimensions out of the PNG's IHDR chunk rather than computing them, so reported size can never disagree with the image sent. An earlier version shelled out to `sips`; it was replaced because rendering smaller is faster than resampling and needs no external tool, which is what makes downsampling work on Windows. The factor is *derived* from the comp when the caller omits one (`__autoDownsample`, aiming at a ~1280px long edge) — which is why `ScreenshotFrame`/`ScreenshotLayer` must not carry a zod `.default(1)`: a default there would reach the panel as an explicit 1 and the derivation would never run.
+
+## Serializing writes
+
+**The panel's `evalScript` mutex is necessary and not sufficient, and the gap it
+leaves is exactly where the damage was.** That chain serializes every individual
+`evalScript`, so two ordinary writes cannot interleave *within* one op — the
+undo group `dispatch()` opens is closed before the next call gets a turn. What
+it does not cover is the gap around a long `run_batch`. Over 500 ops, the
+handler calls `app.beginUndoGroup(name)`, returns `{jobId, async:true}`
+immediately, and the panel then drives `_continue_job` in chunks of 25 with that
+group **still open**. Every chunk is its own turn on the chain, so any op issued
+meanwhile slots in *between* two chunks — and AE's undo groups do not nest, so
+that op's own `endUndoGroup()` closes the batch's group. The rest of the batch
+writes outside any group, and the batch's final `endUndoGroup()` closes whatever
+happens to be open by then. One user action, an unknown number of undo steps,
+and no error anywhere. That is issue #55, and it is why the fix could not be
+"the panel already handles it".
+
+Ordering was the second half. Requests arrive at the server in the order the
+agent issued them, but the old code fired every one at `fetch` in parallel and
+took whatever order the sockets happened to deliver. Two writes where the second
+depends on the first were a coin toss.
+
+So: **one writer at a time, for the whole session.** `bridge/writeQueue.ts` is a
+FIFO mutex; `server.ts` takes a lease before forwarding any op classified
+`"write"`. Five things about it are load-bearing.
+
+- **The classification is a table, not a list of prefixes.** `OpMutation` lives
+  beside `OpSchemas` in `schemas.ts` and covers every op with `"write"`,
+  `"read"` or `"server"`. There is deliberately no default: an op nobody
+  classified would be classified by silence, and the silent answer — "read" — is
+  the one that reintroduces the bug. `tests/unit/write-queue.mjs` fails the
+  build when the two tables disagree in either direction, and `isWriteOp()`
+  falls back to `"write"` at runtime so even a shipped omission costs
+  serialization rather than correctness.
+- **Reads never queue, screenshots least of all.** They are unaffected by an
+  open undo group, and a screenshot is the slowest thing in the system — putting
+  one behind the write mutex would make every write wait on a render for
+  nothing. `await_job` and `cancel_job` are `"server"` for a harder reason: they
+  can be issued *while* the batch holding the lock is running, and queueing
+  either would deadlock against the thing they exist to wait on and release.
+- **The lease outlives its own call.** `extendUntil` is the whole fix. When
+  `run_batch` answers with a jobId, the lock is held until `JobManager` reports
+  the job finished — releasing it when the HTTP call returned would leave
+  precisely the gap described above. A leak guard at twice the wait ceiling
+  covers a job that never reports (a dropped WS); it is set *above* the wait
+  ceiling so that any writer queued behind the batch has hit its own deadline
+  and gone before the hold could expire and hand it the lock mid-batch.
+- **The op timeout starts at execution, never at enqueue.** `AbortSignal.timeout`
+  is created inside `runOp`, and `acquire()` is awaited before it — so a call
+  that waited ten minutes still gets its full budget when it runs. Get this
+  backwards and a queued call times out having never run, reporting a bridge
+  failure for a bridge that was answering fine. That is the one way this feature
+  could have made things worse, and the test that pins it runs the real
+  `HttpClient` against a stub on an ephemeral port.
+- **A cancelled request is dropped, not deferred.** If the MCP request is
+  cancelled while queued, `acquire` rejects and the caller never reaches the
+  bridge. Work that runs after the thing that asked for it gave up is the leak.
+
+A call that waited says so: `queuedBehind` and `waitedMs`, present only when it
+actually waited, so an uncontended result is byte-identical to what it always
+was. They fold into the result object where there is one, which is every writing
+op but `run_jsx` — that returns whatever the caller's script returned, arrays
+and bare numbers included, and rewrapping those would change what every existing
+caller reads (#43). Those get a second text content block instead. Vision
+results never carry a note at all, since screenshots are reads.
+
+Two limits worth knowing. The queue is per-server-process, so a second MCP
+client pointed at the same panel is not serialized against the first — the panel
+is a shared resource with no lock of its own. And the queue is bounded
+(`AE_MCP_WRITE_QUEUE_DEPTH`, default 64; `AE_MCP_WRITE_QUEUE_WAIT_MS`, default
+600s) rather than unbounded, because an agent looping writes at a stuck bridge
+would otherwise grow it without limit.
 
 ## Conventions
 
@@ -286,6 +361,8 @@ That sync is **opt-in on purpose**. The installed bundle is one half of the pane
 19. `.mogrt` thumbnail: give the comp an empty first frame (keyframe every layer's opacity 0 → 100 over the first second), export with no `posterTime` → `thumb.png` inside the zip is solid black. Export again with `posterTime` past the fade → `thumbnail.patched: true` and the frame is in there at AE's own thumbnail dimensions. Unzip and check the *other* entries are byte-identical; a corrupt `project.aegraphic` would not show up in the picture.
 20. Shape reads, on a shape layer with several groups: `get_layer_full({compId, layerId, include:["shape"]})` → no `ADBE Vector Materials Group` anywhere, `materialsOmitted` counting the groups it was dropped from, and every group whose Transform nobody has touched carrying `atDefaults: true` instead of its seven properties. With `shapeMaterials:true` → the 48 properties are back and `materialsOmitted` is gone. A group that is scaled, keyframed or expression-driven must *never* say `atDefaults`. With `shapeDetail:"compact"` → one indented line per group, `[n keys]`/`[expr]` on the animated properties, and a path as `path(7 verts, closed)`. Measured on the layer in issue #42: 13,369 → 3,052 → 643 characters of shape JSON.
 
+21. Write serialization, which needs a live AE because the failure it prevents is in AE's undo stack and nowhere else. Issue two writes in one turn — `create_solid_layer` and `create_text_layer` on the same comp — and check the second result carries `queuedBehind: "create_solid_layer"` and a `waitedMs`, while the first carries neither. Then the real one: `run_batch` with 600 ops (past the 500 inline cutoff) and, in the *same* turn, a `set_transform`. The batch returns its `{jobId}` immediately; the `set_transform` must not return until the job does, and AE's Edit menu afterwards must show the batch as **one** undo step with the transform as a separate one after it. Before this landed the transform went in mid-batch and the batch broke into an arbitrary number of steps. Reads are the control: `list_layers` issued alongside the running batch returns straight away, and `await_job` on the batch resolves rather than hanging (it would hang if it queued).
+
 16. Compiled binary, the one no unit test reaches: run the built binary from an empty directory *and* from `/`, and confirm `setup_panel` installs a populated `node_modules/ws`. Under `bun --compile` the module resolver returns a bare specifier rather than throwing, so this path cannot be exercised under plain Node — see the `require.resolve` note in Known fragile areas.
 
 ## The issue journal
@@ -306,6 +383,7 @@ The user-facing half is the offer to report. It now lives in exactly two places:
 - `saveFrameToPng` is community-known, not officially documented. Alpha edge cases reported on some comps. If it fails, fallback would be the render queue with PNG Sequence template (slow; deferred to v1.1).
 - ExtendScript single-threading: `run_jsx` with a long synchronous loop will freeze AE's UI. Document for the agent in the tool description (already done).
 - **A busy AE is indistinguishable from a dead bridge at the HTTP layer.** ExtendScript is single-threaded, so while a script runs — or a modal dialog sits unclicked — the panel cannot service its socket at all. The connection is accepted and then nothing comes back. That is why `httpClient` separates `BridgeTimeoutError` from `BridgeUnreachableError` and why `check_setup`'s `bridgeReachable` reports a timeout differently from a refusal: the two have opposite remedies, and "restart After Effects" said to someone whose script is still running throws away work for nothing. Enumerating `app.effects` (~250 entries, tens of seconds in 26.3) is the reproducible case — issue #26 — which is also why `list_available_effects` caches for the session. Never collapse the two errors back into one sentence.
+- **There are now three of those, not two, and the third one's advice is the opposite of the second's.** `WriteQueueWaitError` means the call sat behind another write for the full `AE_MCP_WRITE_QUEUE_WAIT_MS` and was dropped **without ever leaving the server**. `BridgeTimeoutError` forbids re-sending, because that call did reach After Effects and may still be running; the queue error has to say the opposite, because nothing was written and re-sending once the queue drains is the correct move. `BridgeUnreachableError` sends the reader to `check_setup`, which the queue error must not, since the bridge is answering perfectly well. Three diagnoses, three remedies, no shared sentences — `tests/unit/write-queue.mjs` asserts they stay distinct, including that neither bridge error ever mentions the queue.
 - **The server's op timeout must sit above the panel's own waits, not on them.** `saveFrameToPng` is asynchronous and the panel polls for the PNG for up to 120s; with the server also at 120s it gave up at the exact moment the panel might still have succeeded. `SLOW_OPS` in `bridge/httpClient.ts` gives the screenshot, `run_jsx` and `run_batch` ops 300s. `AE_MCP_OP_TIMEOUT_MS` overrides every op, deliberately including the slow ones — one number a user can reason about beats a matrix they cannot see.
 - CEP manifest's `<AutoVisible>false</AutoVisible>` was unreliable in early CEP 12 builds. Current manifest uses `AutoVisible=true` with a small geometry — the panel still auto-loads invisibly enough; the user can dock the small status panel out of the way.
 - CEP panels installed without signing require `PlayerDebugMode=1`. The user does this once via `npm run enable:debug` and a reboot.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "uninstall:panel": "node scripts/uninstall-panel.mjs",
     "doctor": "node scripts/doctor.mjs",
     "diagnose:spaces": "node scripts/diagnose-spaces.mjs",
-    "test": "node tests/unit/panel-version.mjs && node tests/unit/panel-paths.mjs && node tests/unit/panel-install.mjs && node tests/unit/panel-boot.mjs && node tests/unit/bridge-timeout.mjs && node tests/unit/png-codec.mjs && node tests/unit/frame-cache.mjs && node tests/unit/mogrt-thumbnail.mjs && node tests/unit/issue-journal.mjs && node tests/unit/jsx-ternary.mjs && node tests/unit/jsx-undo-group.mjs && node tests/unit/run-jsx-result.mjs && node tests/unit/shape-read.mjs && node tests/unit/parent-transform.mjs && node tests/unit/svg-import.mjs && node tests/unit/bundle-determinism.mjs",
+    "test": "node tests/unit/panel-version.mjs && node tests/unit/panel-paths.mjs && node tests/unit/panel-install.mjs && node tests/unit/panel-boot.mjs && node tests/unit/bridge-timeout.mjs && node tests/unit/png-codec.mjs && node tests/unit/frame-cache.mjs && node tests/unit/mogrt-thumbnail.mjs && node tests/unit/issue-journal.mjs && node tests/unit/jsx-ternary.mjs && node tests/unit/jsx-undo-group.mjs && node tests/unit/run-jsx-result.mjs && node tests/unit/shape-read.mjs && node tests/unit/parent-transform.mjs && node tests/unit/svg-import.mjs && node tests/unit/bundle-determinism.mjs && node tests/unit/write-queue.mjs && node tests/unit/write-queue-server.mjs",
     "new:project": "node packages/mcp-server/dist/index.js init",
     "start": "node packages/mcp-server/dist/index.js",
     "inspect": "npx @modelcontextprotocol/inspector node packages/mcp-server/dist/index.js",

--- a/packages/mcp-server/src/bridge/writeQueue.ts
+++ b/packages/mcp-server/src/bridge/writeQueue.ts
@@ -1,0 +1,248 @@
+import { WriteQueueCancelledError, WriteQueueFullError, WriteQueueWaitError } from "../util/errors.js";
+import { logger } from "../util/logger.js";
+
+/**
+ * One writer at a time, for the whole After Effects session.
+ *
+ * The panel already serializes every individual `evalScript`, so two ordinary
+ * writes cannot interleave *inside* one op. What it does not serialize is the
+ * gap around a long `run_batch`: that handler opens `app.beginUndoGroup` and
+ * returns the `{jobId, async}` envelope immediately, then the panel drives
+ * `_continue_job` in chunks with the group still open. Every chunk is its own
+ * turn on the panel's chain, so any other op issued meanwhile slots in between
+ * two chunks — and because AE's undo groups do not nest, that op's own
+ * `endUndoGroup()` closes the *batch's* group. The rest of the batch then
+ * writes outside any group. That is the undo interleaving issue #55 reports,
+ * and closing it is why a lease can be held past the call that took it
+ * (`extendUntil`).
+ *
+ * Reads never come here. They are unaffected by an open undo group, and
+ * screenshots are the slowest thing in the system — putting them behind this
+ * would make every write wait on a render for no benefit.
+ */
+
+/** What a call reports when it did not get the lock immediately. */
+export interface QueueWait {
+  /** The op that held the lock at the moment this one joined the queue. */
+  queuedBehind: string;
+  waitedMs: number;
+}
+
+export interface WriteLease {
+  /** null when the lock was free — the overwhelmingly common case. */
+  readonly wait: QueueWait | null;
+  /**
+   * Keep the lock past `release()` until `p` settles.
+   *
+   * For `run_batch`: the panel answers with a jobId while the batch's undo
+   * group is still open, so the lock has to outlive the HTTP call that took it.
+   * Rejections are swallowed — a failed job still ends the undo group.
+   */
+  extendUntil(p: Promise<unknown>): void;
+  /** Idempotent. A no-op after the first call. */
+  release(): void;
+}
+
+const DEFAULT_MAX_WAIT_MS = 600_000;
+const DEFAULT_MAX_DEPTH = 64;
+
+/**
+ * How long a call may sit in the queue before it is dropped unrun.
+ *
+ * Generous on purpose: the thing in front is legitimately slow (a long batch,
+ * a big `run_jsx`) far more often than it is stuck, and dropping a write the
+ * user asked for costs more than waiting.
+ */
+export function queueWaitMs(): number {
+  return envNumber("AE_MCP_WRITE_QUEUE_WAIT_MS", DEFAULT_MAX_WAIT_MS);
+}
+
+export function queueMaxDepth(): number {
+  return envNumber("AE_MCP_WRITE_QUEUE_DEPTH", DEFAULT_MAX_DEPTH);
+}
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (Number.isFinite(n) && n > 0) return n;
+  logger.warn(`Ignoring ${name}=${raw} — expected a positive number.`);
+  return fallback;
+}
+
+interface Waiter {
+  op: string;
+  enqueuedAt: number;
+  behind: string;
+  settle: (lease: WriteLease) => void;
+  fail: (err: Error) => void;
+  /** Set once the waiter has been resolved, rejected, cancelled or timed out. */
+  done: boolean;
+  cleanup: () => void;
+}
+
+export class WriteQueue {
+  private holder: string | null = null;
+  private waiting: Waiter[] = [];
+  private readonly maxWaitMs: number;
+  private readonly maxDepth: number;
+
+  constructor(opts: { maxWaitMs?: number; maxDepth?: number } = {}) {
+    this.maxWaitMs = opts.maxWaitMs ?? queueWaitMs();
+    this.maxDepth = opts.maxDepth ?? queueMaxDepth();
+  }
+
+  /** For tests and diagnostics. */
+  get depth(): number { return this.waiting.filter((w) => !w.done).length; }
+  get held(): string | null { return this.holder; }
+
+  /**
+   * The longest a lease may be held past its call by `extendUntil` — a leak
+   * guard for a job that never reports completion (a dropped WS, say).
+   *
+   * Twice the wait ceiling on purpose. Anything already queued behind that job
+   * has hit its own deadline and gone by then, so expiring the hold can never
+   * hand the lock to a writer while the batch is still going.
+   */
+  get holdCeilingMs(): number { return this.maxWaitMs * 2; }
+
+  /**
+   * Wait for the lock, then return the lease.
+   *
+   * Rejects rather than resolving late when the request was cancelled, when the
+   * wait ran past `maxWaitMs`, or when the queue is full. In every one of those
+   * cases the caller must not go on to hit the bridge — nothing was written,
+   * and the error says so, which is what makes re-sending safe there and unsafe
+   * after a bridge timeout.
+   */
+  acquire(op: string, signal?: AbortSignal): Promise<WriteLease> {
+    if (signal?.aborted) {
+      return Promise.reject(new WriteQueueCancelledError(op));
+    }
+    if (this.holder === null && this.depth === 0) {
+      this.holder = op;
+      return Promise.resolve(this.makeLease(null));
+    }
+    if (this.depth >= this.maxDepth) {
+      return Promise.reject(new WriteQueueFullError(op, this.maxDepth, this.holder ?? "another write"));
+    }
+
+    const behind = this.holder ?? this.waiting.find((w) => !w.done)?.op ?? "another write";
+    return new Promise<WriteLease>((resolve, reject) => {
+      const waiter: Waiter = {
+        op,
+        enqueuedAt: Date.now(),
+        behind,
+        done: false,
+        settle: resolve,
+        fail: reject,
+        cleanup: () => {},
+      };
+
+      const timer = setTimeout(() => {
+        if (waiter.done) return;
+        waiter.done = true;
+        waiter.cleanup();
+        // Timing out in the queue frees nothing: whoever is in front still holds
+        // the lock. Just stop waiting.
+        reject(new WriteQueueWaitError(op, this.maxWaitMs, waiter.behind));
+        this.pump();
+      }, this.maxWaitMs);
+      // A queued write must never be the reason the process stays alive.
+      timer.unref?.();
+
+      const onAbort = () => {
+        if (waiter.done) return;
+        waiter.done = true;
+        waiter.cleanup();
+        // Dropped, never executed. A cancelled request whose work runs later is
+        // the leak this exists to avoid.
+        reject(new WriteQueueCancelledError(op));
+        this.pump();
+      };
+
+      waiter.cleanup = () => {
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+
+      this.waiting.push(waiter);
+    });
+  }
+
+  private makeLease(wait: QueueWait | null): WriteLease {
+    let released = false;
+    let hold: Promise<unknown> | null = null;
+    const queue = this;
+    return {
+      wait,
+      extendUntil(p: Promise<unknown>) {
+        hold = p;
+        if (released) settleHold();
+      },
+      release() {
+        if (released) return;
+        released = true;
+        if (hold) settleHold();
+        else queue.handOff();
+      },
+    };
+
+    function settleHold() {
+      const p = hold;
+      hold = null;
+      if (!p) return;
+      const ceiling = queue.holdCeilingMs;
+      let fired = false;
+      const done = () => {
+        if (fired) return;
+        fired = true;
+        queue.handOff();
+      };
+      const t = setTimeout(() => {
+        if (fired) return;
+        logger.warn(
+          `A write held the After Effects queue for over ${Math.round(ceiling / 1000)}s without its job reporting completion; releasing it.`
+        );
+        done();
+      }, ceiling);
+      t.unref?.();
+      p.then(done, done).finally(() => clearTimeout(t));
+    }
+  }
+
+  private handOff(): void {
+    this.holder = null;
+    this.pump();
+  }
+
+  private pump(): void {
+    if (this.holder !== null) return;
+    while (this.waiting.length > 0) {
+      const next = this.waiting.shift()!;
+      if (next.done) continue;
+      next.done = true;
+      next.cleanup();
+      this.holder = next.op;
+      next.settle(this.makeLease({ queuedBehind: next.behind, waitedMs: Date.now() - next.enqueuedAt }));
+      return;
+    }
+  }
+}
+
+/**
+ * Fold the queue note into a result.
+ *
+ * Returns the merged object, or `null` when there is nothing safe to merge
+ * into: `run_jsx` hands back whatever the caller's script returned — arrays,
+ * numbers, strings — and rewrapping those would change what every existing
+ * caller reads. The server sends those as a second text block instead, which
+ * cannot corrupt any envelope.
+ */
+export function mergeWait(value: unknown, wait: QueueWait): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const obj = value as Record<string, unknown>;
+  if ("queuedBehind" in obj || "waitedMs" in obj) return null;
+  return { ...obj, ...wait };
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { schemas } from "@engineroom/shared";
 import { HttpClient } from "./bridge/httpClient.js";
 import { WsClient } from "./bridge/wsClient.js";
+import { WriteQueue, mergeWait, type QueueWait, type WriteLease } from "./bridge/writeQueue.js";
 import { JobManager } from "./jobs/manager.js";
 import { descriptions } from "./tools/descriptions.js";
 import { AeError, BridgeTimeoutError, BridgeUnreachableError } from "./util/errors.js";
@@ -36,7 +37,7 @@ const ASYNC_OPS = new Set(["run_batch"]);
 // especially must never touch the bridge — they exist precisely for the case
 // where the panel is not installed yet, which is also when the issue journal is
 // most likely to be written to.
-const SERVER_OPS = new Set([
+export const SERVER_OPS = new Set([
   "await_job",
   "get_job",
   "cancel_job",
@@ -48,6 +49,20 @@ const SERVER_OPS = new Set([
   "list_known_issues",
   "mark_issue_reported",
 ]);
+
+/**
+ * True for an op that changes the After Effects session, from the one table
+ * that is checked against `OpSchemas` at test time (`schemas.OpMutation`).
+ *
+ * A hand-kept list here would go stale the first time somebody added a tool,
+ * and the failure would be silent — a new writing op classified by omission as
+ * a read, interleaving with a batch. Anything this cannot classify is treated
+ * as a write, which costs a little serialization and never costs correctness.
+ */
+export function isWriteOp(name: string): boolean {
+  const effect = (schemas.OpMutation as Record<string, string | undefined>)[name];
+  return effect === undefined ? true : effect === "write";
+}
 
 /**
  * `ae_guide` exists because the two better carriers are not universal. The
@@ -78,6 +93,9 @@ export function createServer() {
 
   const bridge = new HttpClient();
   const jobs = new JobManager();
+  // One writer at a time. See bridge/writeQueue.ts for why the panel's own
+  // evalScript mutex is not enough.
+  const writes = new WriteQueue();
   const ws = new WsClient(bridge.port, jobs);
   ws.start();
   const panelGate = createPanelGate(bridge);
@@ -261,6 +279,24 @@ export function createServer() {
     const staleness = await panelGate.check();
     if (staleness) return errorResult(staleness);
 
+    // Serialize writes. Acquiring *before* runOp is what keeps the op timeout
+    // honest: `AbortSignal.timeout` is created inside `runOp`, so the clock
+    // starts when the call executes and not when it entered the queue. A queued
+    // call that timed out having never run would report a bridge failure for a
+    // bridge that was working, which is the one way this feature could make
+    // things worse than they were.
+    let lease: WriteLease | null = null;
+    if (isWriteOp(name)) {
+      try {
+        lease = await writes.acquire(name, extra?.signal);
+      } catch (e) {
+        // Full, timed out in the queue, or cancelled — all three mean the call
+        // never reached After Effects, and all three say so.
+        return errorResult((e as Error).message);
+      }
+    }
+    const wait: QueueWait | null = lease?.wait ?? null;
+
     // Forward to panel.
     try {
       const result = await bridge.runOp(name, args, progressToken);
@@ -277,7 +313,23 @@ export function createServer() {
             });
           });
         }
-        return textResult({ jobId: env.jobId, async: true, total: env.total });
+        // This is the gap the panel's own mutex leaves, and the reason this
+        // queue exists at all. `run_batch` opened `app.beginUndoGroup` and
+        // handed back a jobId; the panel now drives `_continue_job` chunk by
+        // chunk with that group still OPEN. Each chunk is its own turn on the
+        // panel's evalScript chain, so releasing the lock here lets the next
+        // write land between two chunks — inside the batch's undo group, whose
+        // `endUndoGroup()` then closes it early. Hold the lock until the job
+        // reports done.
+        //
+        // `await_job` is server-resident and never takes this lock, so an agent
+        // waiting on the job it queued behind cannot deadlock against it.
+        //
+        // `waitFor`'s own timeout has to sit at the queue's hold ceiling, not
+        // below it — a shorter one here would release the lock mid-batch while
+        // a writer that queued at the same moment was still waiting.
+        lease?.extendUntil(jobs.waitFor(env.jobId, writes.holdCeilingMs));
+        return textResult({ jobId: env.jobId, async: true, total: env.total }, wait);
       }
 
       // An empty frame is reported, never shipped. The panel found every pixel
@@ -317,7 +369,7 @@ export function createServer() {
         );
       }
 
-      return textResult(result);
+      return textResult(result, wait);
     } catch (e) {
       // Checked before BridgeUnreachableError because the remedies are
       // opposites: one says restart After Effects, the other says do not.
@@ -338,6 +390,10 @@ export function createServer() {
         return errorResult(`AE: ${e.message}${e.line ? ` (line ${e.line})` : ""}`);
       }
       return errorResult((e as Error).message);
+    } finally {
+      // No-op unless a lease was taken, and deferred by `extendUntil` when a
+      // long batch is still running behind the envelope we just returned.
+      lease?.release();
     }
   });
 
@@ -415,10 +471,24 @@ async function clientRoots(server: Server): Promise<string[] | undefined> {
   }
 }
 
-function textResult(value: unknown) {
-  return {
-    content: [{ type: "text" as const, text: JSON.stringify(value, null, 2) }],
-  };
+/**
+ * `wait` is present only when the call actually sat in the write queue, so the
+ * ordinary result is byte-identical to what it has always been.
+ *
+ * It is folded into the result object where there is one — which is every
+ * writing op but `run_jsx`, whose result is whatever the caller's script
+ * returned. Arrays and bare numbers get a second text block instead: rewrapping
+ * them would change what every existing caller reads, and #43 is the standing
+ * reminder that changing what a `run_jsx` answer looks like is expensive.
+ * Vision results never come through here with a wait — screenshots are reads
+ * and are never queued — so the image envelope cannot be touched by this.
+ */
+function textResult(value: unknown, wait?: QueueWait | null) {
+  const json = (v: unknown) => ({ type: "text" as const, text: JSON.stringify(v, null, 2) });
+  if (!wait) return { content: [json(value)] };
+  const merged = mergeWait(value, wait);
+  if (merged) return { content: [json(merged)] };
+  return { content: [json(value), json(wait)] };
 }
 
 function errorResult(message: string) {

--- a/packages/mcp-server/src/util/errors.ts
+++ b/packages/mcp-server/src/util/errors.ts
@@ -103,3 +103,79 @@ export class AeError extends Error {
     this.name = "AeError";
   }
 }
+
+/**
+ * The third case, and it must not be read as either of the first two.
+ *
+ * `BridgeUnreachableError` means the panel is not there. `BridgeTimeoutError`
+ * means it is there and busy — and it forbids re-sending, because the call did
+ * reach After Effects and may still be running. This one is the opposite of
+ * both: the call never left the server, nothing was written, and re-sending is
+ * the correct next move once the queue drains. Collapsing it into the timeout
+ * message would tell the reader not to re-send work that never happened, and
+ * collapsing it into the unreachable message would send them off restarting a
+ * bridge that is answering perfectly well.
+ */
+export class WriteQueueWaitError extends Error {
+  constructor(public op: string, public waitedMs: number, public behind: string) {
+    super(WriteQueueWaitError.message(op, waitedMs, behind));
+    this.name = "WriteQueueWaitError";
+  }
+  static message(op: string, waitedMs: number, behind: string): string {
+    const secs = Math.round(waitedMs / 1000);
+    return [
+      `\`${op}\` waited ${secs}s behind \`${behind}\` for the After Effects write queue and was dropped without running.`,
+      "",
+      "This is neither a lost connection nor a busy bridge. The panel is fine and this",
+      "call never reached After Effects, so nothing in the project was changed.",
+      "",
+      "Writes are serialized because After Effects applies every change through one undo",
+      "stack; two in flight interleave and corrupt it. Something in front of this call is",
+      "taking a very long time — most often a long run_batch, occasionally a modal dialog",
+      "in After Effects blocking the script in front.",
+      "",
+      "What to do, in order:",
+      "1. Nothing was written, so re-sending this call is safe — unlike a bridge timeout.",
+      "   Wait for the work in front to finish first, or it will just queue again.",
+      "2. Find out what is in front: get_job or await_job for a batch. Reads are not",
+      "   queued, so list_/get_ calls still work and will tell you the current state.",
+      "3. Ask the user to look at After Effects for a dialog nobody has clicked.",
+      `4. If the work in front is legitimately this long, raise the limit: start the`,
+      "   server with AE_MCP_WRITE_QUEUE_WAIT_MS set to a larger number of milliseconds.",
+    ].join("\n");
+  }
+}
+
+/** Backpressure, so a client that fires writes in a loop cannot grow the queue without bound. */
+export class WriteQueueFullError extends Error {
+  constructor(public op: string, public maxDepth: number, public behind: string) {
+    super(WriteQueueFullError.message(op, maxDepth, behind));
+    this.name = "WriteQueueFullError";
+  }
+  static message(op: string, maxDepth: number, behind: string): string {
+    return [
+      `The After Effects write queue is full — ${maxDepth} calls are already waiting, so \`${op}\` was refused.`,
+      "",
+      `Nothing was written. Writes are serialized (one undo stack), and \`${behind}\` is`,
+      "holding the queue up.",
+      "",
+      "Stop issuing writes and let it drain — reads are not queued, so list_/get_ calls",
+      "still work. If you have this much independent work to do, send it as one",
+      "run_batch instead of as many calls: that is one ExtendScript pass and one undo step.",
+      "AE_MCP_WRITE_QUEUE_DEPTH raises the limit if you really need it raised.",
+    ].join("\n");
+  }
+}
+
+/**
+ * The request was cancelled while its write was still queued.
+ *
+ * Reported rather than swallowed: the client has usually stopped listening by
+ * now, but if it has not, "this never ran" is the one thing it needs to know.
+ */
+export class WriteQueueCancelledError extends Error {
+  constructor(public op: string) {
+    super(`\`${op}\` was cancelled while waiting for the After Effects write queue. It never ran, and nothing was changed.`);
+    this.name = "WriteQueueCancelledError";
+  }
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -745,3 +745,126 @@ export const OpSchemas = {
 } as const;
 
 export type OpName = keyof typeof OpSchemas;
+
+/**
+ * What each op does to the live After Effects session.
+ *
+ * ════════════════════════════════════════════════════════════════════════════
+ *  ADDING AN OP? ADD IT HERE TOO. `tests/unit/write-queue.mjs` fails the build
+ *  when an op is in `OpSchemas` and not in this table, or the other way round.
+ * ════════════════════════════════════════════════════════════════════════════
+ *
+ * There is deliberately no default. Guessing "read" for an op nobody
+ * classified would let a new writing tool run inside another write's undo group
+ * and corrupt it silently, which is the exact failure this table exists to
+ * prevent (issue #55) — so an unclassified op has to fail the build instead.
+ *
+ *   "write"  — changes the project or the application. The server serializes
+ *              these behind one mutex: After Effects applies every change
+ *              through a single undo stack, and two in flight interleave.
+ *   "read"   — reaches the bridge and changes nothing. Never queued. Screenshots
+ *              are here on purpose: they are slow *and* read-only, and putting
+ *              them behind the write mutex would make every write wait on a render.
+ *   "server" — never reaches the bridge at all (`SERVER_OPS` in server.ts).
+ *              Not queued, and that is load-bearing: `await_job` blocks for as
+ *              long as a batch runs and `cancel_job` is how a stuck one is
+ *              released, so queueing either would deadlock against the job
+ *              holding the lock.
+ */
+export const OpMutation = {
+  // comps
+  list_comps: "read",
+  get_comp: "read",
+  get_comp_tree: "read",
+  create_comp: "write",
+  set_comp: "write",
+  delete_comp: "write",
+  set_active_comp: "write",
+  // layers
+  list_layers: "read",
+  get_layer_full: "read",
+  create_text_layer: "write",
+  create_shape_layer: "write",
+  create_solid_layer: "write",
+  create_null_layer: "write",
+  create_adjustment_layer: "write",
+  create_precomp_layer: "write",
+  create_camera_layer: "write",
+  create_light_layer: "write",
+  duplicate_layer: "write",
+  delete_layer: "write",
+  set_layer: "write",
+  parent_layer: "write",
+  reorder_layer: "write",
+  // transforms
+  set_transform: "write",
+  // keyframes
+  add_keyframe: "write",
+  remove_keyframe: "write",
+  get_keyframes: "read",
+  set_interpolation: "write",
+  set_temporal_ease: "write",
+  set_spatial_tangents: "write",
+  // expressions
+  get_expression: "read",
+  set_expression: "write",
+  toggle_expression: "write",
+  clear_expression: "write",
+  // effects
+  list_effects: "read",
+  add_effect: "write",
+  remove_effect: "write",
+  set_effect_param: "write",
+  set_effect_enabled: "write",
+  list_available_effects: "read",
+  // text
+  set_text: "write",
+  add_text_animator: "write",
+  // shapes
+  set_shape_path: "write",
+  add_shape_content: "write",
+  set_shape_property: "write",
+  // masks
+  add_mask: "write",
+  set_mask: "write",
+  remove_mask: "write",
+  // markers
+  add_marker: "write",
+  remove_marker: "write",
+  // vision — read-only despite being the slowest thing here. `screenshot_*`
+  // borrows the comp's resolutionFactor and restores it in a `finally`;
+  // nothing in the project changes.
+  screenshot_frame: "read",
+  screenshot_layer: "read",
+  // batch
+  run_batch: "write",
+  // explore
+  get_project_summary: "read",
+  find_layers: "read",
+  // footage
+  import_footage: "write",
+  create_footage_layer: "write",
+  // motion graphics templates — saves the project before exporting.
+  export_mogrt: "write",
+  // raw — the script is the caller's and may do anything. Assume the worst.
+  run_jsx: "write",
+  // house style — written over the bridge into a file beside the .aep.
+  get_house_style: "read",
+  set_house_style: "write",
+  // jobs
+  await_job: "server",
+  get_job: "server",
+  cancel_job: "server",
+  // setup
+  check_setup: "server",
+  setup_panel: "server",
+  init_project: "server",
+  // guidance
+  ae_guide: "server",
+  // issue journal
+  log_issue: "server",
+  list_known_issues: "server",
+  mark_issue_reported: "server",
+} as const satisfies Record<OpName, "write" | "read" | "server">;
+
+export type OpEffect = (typeof OpMutation)[OpName];

--- a/tests/unit/write-queue-server.mjs
+++ b/tests/unit/write-queue-server.mjs
@@ -1,0 +1,203 @@
+// The write queue as the agent actually meets it: through tools/call.
+//
+// tests/unit/write-queue.mjs covers the queue itself. This one covers the
+// wiring, which is the half that would fail silently — a `wait` not threaded to
+// one of the three return sites, or `acquire` called on the wrong side of the
+// panel gate, leaves the queue working perfectly and reporting nothing.
+//
+// It drives the real MCP server over an in-memory transport against a stub
+// bridge on an ephemeral port. There is no After Effects here and none is
+// needed: everything asserted is server-side.
+//
+//   node tests/unit/write-queue-server.mjs
+
+import assert from "node:assert/strict";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { WebSocketServer } from "ws";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dist = (...p) =>
+  pathToFileURL(path.join(root, "packages", "mcp-server", "dist", ...p)).href;
+
+const { sourceBundleHash } = await import(dist("setup", "panelVersion.js"));
+
+// ---------------------------------------------------------------------------
+// Stub bridge. Never port 7777 — a real panel may hold that on this machine.
+// ---------------------------------------------------------------------------
+
+/** op -> how long the stub takes, and what it answers. */
+const behaviour = new Map();
+/** Every op the stub saw, with the moment it entered and left. */
+const seen = [];
+
+const bridge = http.createServer((req, res) => {
+  if (req.url === "/health") {
+    res.setHeader("content-type", "application/json");
+    // Report the hash this server ships so the panel-version gate is a no-op
+    // rather than a variable of whatever is installed on the test machine.
+    res.end(JSON.stringify({ ok: true, port: 0, bundleLoaded: true, bundleHash: sourceBundleHash() }));
+    return;
+  }
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", async () => {
+    const { op } = JSON.parse(body || "{}");
+    const b = behaviour.get(op) ?? { ms: 5, result: { ok: true, op } };
+    const entry = { op, enteredAt: Date.now() };
+    seen.push(entry);
+    await new Promise((r) => setTimeout(r, b.ms));
+    entry.leftAt = Date.now();
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ ok: true, result: b.result }));
+  });
+});
+const wss = new WebSocketServer({ server: bridge, path: "/events" });
+await new Promise((r) => bridge.listen(0, "127.0.0.1", r));
+const port = bridge.address().port;
+assert.notEqual(port, 7777, "must not bind the panel's port");
+process.env.AE_MCP_PORT = String(port);
+
+// Imported only after AE_MCP_PORT is set: HttpClient resolves the port in its
+// constructor, which runs inside createServer().
+const { createServer } = await import(dist("server.js"));
+const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
+const { InMemoryTransport } = await import("@modelcontextprotocol/sdk/inMemory.js");
+
+const server = createServer();
+const client = new Client({ name: "write-queue-test", version: "0" }, { capabilities: {} });
+const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+await Promise.all([server.connect(serverSide), client.connect(clientSide)]);
+
+let passed = 0;
+async function check(name, fn) {
+  await fn();
+  passed++;
+}
+async function call(name, args = {}) {
+  const res = await client.callTool({ name, arguments: args });
+  if (res.isError) throw new Error(`${name} failed: ${res.content[0]?.text}`);
+  return res;
+}
+const payload = (res, i = 0) => JSON.parse(res.content[i].text);
+const overlapped = (a, b) => {
+  const x = seen.find((s) => s.op === a);
+  const y = seen.find((s) => s.op === b);
+  return x.enteredAt < y.leftAt && y.enteredAt < x.leftAt;
+};
+
+// ---------------------------------------------------------------------------
+
+await check("two concurrent writes reach the bridge one at a time", async () => {
+  seen.length = 0;
+  behaviour.set("set_transform", { ms: 120, result: { ok: true, which: "set_transform" } });
+  behaviour.set("add_keyframe", { ms: 5, result: { ok: true, which: "add_keyframe" } });
+
+  const [first, second] = await Promise.all([
+    call("set_transform", { compId: 1, layerId: 1, properties: { opacity: 50 } }),
+    call("add_keyframe", { compId: 1, layerId: 1, propertyPath: ["Position"], time: 0, value: [0, 0] }),
+  ]);
+
+  assert.deepEqual(seen.map((s) => s.op), ["set_transform", "add_keyframe"]);
+  assert.equal(overlapped("set_transform", "add_keyframe"), false, "the two writes overlapped at the bridge");
+
+  // The one that went straight through says nothing about the queue…
+  const a = payload(first);
+  assert.equal("queuedBehind" in a, false);
+  assert.equal("waitedMs" in a, false);
+  // …and the one that waited names what it waited behind.
+  const b = payload(second);
+  assert.equal(b.queuedBehind, "set_transform");
+  assert.ok(b.waitedMs >= 80, `waitedMs was ${b.waitedMs}`);
+  assert.equal(b.which, "add_keyframe", "the op's own result must survive the annotation");
+});
+
+await check("a read issued behind a slow write is not made to wait for it", async () => {
+  seen.length = 0;
+  behaviour.set("run_jsx", { ms: 150, result: { ok: true } });
+  behaviour.set("list_comps", { ms: 5, result: [] });
+
+  const [, read] = await Promise.all([
+    call("run_jsx", { code: "return 1" }),
+    call("list_comps", {}),
+  ]);
+
+  assert.equal(overlapped("run_jsx", "list_comps"), true, "the read should have run during the write");
+  // A read never queues, so it never carries a queue note.
+  assert.equal(read.content.length, 1);
+  assert.deepEqual(payload(read), []);
+});
+
+await check("a run_jsx result that is not an object keeps its shape", async () => {
+  // #43's lesson: what a run_jsx answer looks like is load-bearing. An array
+  // cannot absorb the queue note, so it arrives as a second content block and
+  // the first block is byte-for-byte what it would have been.
+  seen.length = 0;
+  behaviour.set("set_text", { ms: 120, result: { ok: true } });
+  behaviour.set("run_jsx", { ms: 5, result: ["a", "b"] });
+
+  const [, jsx] = await Promise.all([
+    call("set_text", { compId: 1, layerId: 1, text: "x" }),
+    call("run_jsx", { code: "return ['a','b']" }),
+  ]);
+
+  assert.equal(jsx.content.length, 2, "the note must not be folded into an array");
+  assert.deepEqual(payload(jsx, 0), ["a", "b"]);
+  assert.equal(payload(jsx, 1).queuedBehind, "set_text");
+});
+
+await check("an uncontended write is byte-identical to what it always was", async () => {
+  seen.length = 0;
+  behaviour.set("create_comp", { ms: 5, result: { id: 42, name: "t" } });
+  const res = await call("create_comp", { name: "t", width: 1920, height: 1080, frameRate: 30, duration: 5 });
+  assert.equal(res.content.length, 1);
+  assert.deepEqual(payload(res), { id: 42, name: "t" });
+});
+
+await check("a long batch holds the queue until the job finishes", async () => {
+  // The gap the panel's own evalScript mutex leaves, and the whole reason for
+  // this queue: run_batch answers with a jobId while its undo group is still
+  // open, and the panel goes on driving _continue_job in the background. A
+  // write let through here would land inside that group.
+  seen.length = 0;
+  behaviour.set("run_batch", { ms: 5, result: { jobId: "j_test_1", async: true, total: 600 } });
+  behaviour.set("set_layer", { ms: 5, result: { ok: true } });
+
+  const batch = await call("run_batch", { ops: [{ op: "create_null_layer", args: { compId: 1 } }] });
+  assert.deepEqual(payload(batch), { jobId: "j_test_1", async: true, total: 600 });
+
+  let landed = false;
+  const queued = call("set_layer", { compId: 1, layerId: 1, name: "n" }).then((r) => { landed = true; return r; });
+
+  await new Promise((r) => setTimeout(r, 120));
+  assert.equal(landed, false, "a write reached the bridge while the batch was still running");
+  assert.equal(seen.some((s) => s.op === "set_layer"), false);
+
+  // What the panel broadcasts over /events when the batch finishes.
+  for (const ws of wss.clients) ws.send(JSON.stringify({ type: "complete", jobId: "j_test_1", result: { results: [] } }));
+
+  const res = await queued;
+  assert.equal(payload(res).queuedBehind, "run_batch");
+  assert.ok(payload(res).waitedMs >= 100);
+});
+
+await check("await_job does not deadlock against the batch holding the lock", async () => {
+  seen.length = 0;
+  behaviour.set("run_batch", { ms: 5, result: { jobId: "j_test_2", async: true, total: 600 } });
+  await call("run_batch", { ops: [{ op: "create_null_layer", args: { compId: 1 } }] });
+
+  // await_job is server-resident: it takes no lease, so it can still be
+  // answered while the batch's lease is held. If it queued, this would hang.
+  const awaited = call("await_job", { jobId: "j_test_2", timeoutMs: 5000 });
+  await new Promise((r) => setTimeout(r, 50));
+  for (const ws of wss.clients) ws.send(JSON.stringify({ type: "complete", jobId: "j_test_2", result: { results: [1] } }));
+
+  const state = payload(await awaited);
+  assert.equal(state.status, "completed");
+});
+
+console.log(`write-queue-server: ${passed} checks passed`);
+// The bridge stub's WS client reconnects on a timer the server owns, so there
+// is nothing to await here — same reason panel-boot.mjs ends this way.
+process.exit(0);

--- a/tests/unit/write-queue.mjs
+++ b/tests/unit/write-queue.mjs
@@ -1,0 +1,470 @@
+// The server-side write mutex (issue #55).
+//
+// Worth testing offline and in full, because every property here is invisible
+// when it breaks. A queue that lets two writes overlap looks exactly like one
+// that does not until an undo group is corrupted in someone's real project; a
+// queue that starts the op timeout at enqueue produces a bridge-failure message
+// for a bridge that was working; a queue that executes a cancelled call leaks
+// work into a session that asked for none of it. None of that needs After
+// Effects to prove — it is all server-side TypeScript.
+//
+//   node tests/unit/write-queue.mjs
+
+import assert from "node:assert/strict";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const dist = (...p) =>
+  pathToFileURL(path.join(root, "packages", "mcp-server", "dist", ...p)).href;
+const sharedDist = (...p) =>
+  pathToFileURL(path.join(root, "packages", "shared", "dist", ...p)).href;
+
+const { WriteQueue, mergeWait } = await import(dist("bridge", "writeQueue.js"));
+const { HttpClient } = await import(dist("bridge", "httpClient.js"));
+const { JobManager } = await import(dist("jobs", "manager.js"));
+const { WriteQueueCancelledError, WriteQueueFullError, WriteQueueWaitError, BridgeTimeoutError, BridgeUnreachableError } =
+  await import(dist("util", "errors.js"));
+const { SERVER_OPS, isWriteOp } = await import(dist("server.js"));
+const { OpSchemas, OpMutation } = await import(sharedDist("schemas.js"));
+
+let passed = 0;
+async function check(name, fn) {
+  await fn();
+  passed++;
+}
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Classification. The deliverable that keeps the rest honest: a table nobody
+// updates is worse than no table, because an op omitted from it would be
+// classified by silence.
+// ---------------------------------------------------------------------------
+
+const opNames = Object.keys(OpSchemas);
+const classified = Object.keys(OpMutation);
+
+await check("every op in OpSchemas is classified", () => {
+  const missing = opNames.filter((n) => !(n in OpMutation));
+  assert.deepEqual(
+    missing,
+    [],
+    `unclassified op(s): ${missing.join(", ")}\n` +
+      "Add them to OpMutation in packages/shared/src/schemas.ts — \"write\" if the op\n" +
+      "changes the project or the app, \"read\" if it only looks, \"server\" if it never\n" +
+      "reaches the bridge."
+  );
+});
+
+await check("nothing is classified that is not an op", () => {
+  const extra = classified.filter((n) => !(n in OpSchemas));
+  assert.deepEqual(extra, [], `OpMutation names an op that no longer exists: ${extra.join(", ")}`);
+});
+
+await check("every classification is one of the three buckets", () => {
+  for (const [op, effect] of Object.entries(OpMutation)) {
+    assert.ok(["write", "read", "server"].includes(effect), `${op} is classified ${JSON.stringify(effect)}`);
+  }
+});
+
+await check("the two tables agree on what never reaches the bridge", () => {
+  for (const op of SERVER_OPS) {
+    assert.equal(OpMutation[op], "server", `${op} is in SERVER_OPS but classified ${OpMutation[op]}`);
+  }
+  for (const [op, effect] of Object.entries(OpMutation)) {
+    if (effect === "server") assert.ok(SERVER_OPS.has(op), `${op} is classified "server" but is not in SERVER_OPS`);
+  }
+});
+
+// The specific exemptions issue #55 and the brief call out by name. If one of
+// these ever flips to "write", every write in the session starts waiting on a
+// render or, worse, deadlocks against the job it is waiting for.
+await check("reads that must never queue", () => {
+  for (const op of [
+    "list_comps", "list_layers", "list_effects", "get_comp", "get_layer_full",
+    "get_keyframes", "get_project_summary", "find_layers", "screenshot_frame",
+    "screenshot_layer", "get_house_style", "get_expression",
+  ]) {
+    assert.equal(OpMutation[op], "read", op);
+    assert.equal(isWriteOp(op), false, op);
+  }
+});
+
+await check("await_job and cancel_job must never take the lock", () => {
+  // await_job blocks for as long as the batch it is waiting on; cancel_job is
+  // how a stuck batch is released. Queueing either behind that batch's own
+  // lease is a deadlock, not a slowdown.
+  for (const op of ["await_job", "get_job", "cancel_job", "check_setup", "ae_guide", "list_known_issues"]) {
+    assert.equal(isWriteOp(op), false, op);
+  }
+});
+
+await check("the writers the issue names are writers", () => {
+  for (const op of [
+    "create_comp", "create_text_layer", "set_transform", "delete_layer",
+    "add_keyframe", "remove_keyframe", "run_jsx", "run_batch", "import_footage",
+    "set_expression", "export_mogrt", "set_house_style",
+  ]) {
+    assert.equal(OpMutation[op], "write", op);
+    assert.equal(isWriteOp(op), true, op);
+  }
+});
+
+await check("an op nobody classified is treated as a write, not as a read", () => {
+  // Belt to the test's braces. The build fails above, but if it somehow ships,
+  // the runtime must fail towards serializing rather than towards interleaving.
+  assert.equal(isWriteOp("some_op_added_after_this_test_was_written"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Mutual exclusion
+// ---------------------------------------------------------------------------
+
+/** Records the exact enter/exit interleaving of everything run through it. */
+function tracer() {
+  const log = [];
+  return {
+    log,
+    async run(queue, op, ms, opts = {}) {
+      const lease = queue ? await queue.acquire(op, opts.signal) : null;
+      log.push(`+${op}`);
+      try {
+        await sleep(ms);
+        return lease?.wait ?? null;
+      } finally {
+        log.push(`-${op}`);
+        lease?.release();
+      }
+    },
+  };
+}
+
+await check("two concurrent writes run strictly in sequence", async () => {
+  const q = new WriteQueue();
+  const t = tracer();
+  await Promise.all([t.run(q, "set_transform", 40), t.run(q, "add_keyframe", 10)]);
+  assert.deepEqual(t.log, ["+set_transform", "-set_transform", "+add_keyframe", "-add_keyframe"]);
+});
+
+await check("writes stay in the order they were issued", async () => {
+  const q = new WriteQueue();
+  const t = tracer();
+  await Promise.all(["a", "b", "c", "d"].map((n) => t.run(q, n, 5)));
+  assert.deepEqual(t.log, ["+a", "-a", "+b", "-b", "+c", "-c", "+d", "-d"]);
+});
+
+await check("reads overlap writes freely", async () => {
+  const q = new WriteQueue();
+  const t = tracer();
+  // Reads pass `null` for the queue, exactly as the server does: it only calls
+  // acquire() when isWriteOp() says so.
+  await Promise.all([
+    t.run(q, "run_jsx", 40),
+    t.run(null, "screenshot_frame", 10),
+    t.run(null, "get_layer_full", 5),
+  ]);
+  // Both reads finished while the write was still running.
+  assert.equal(t.log.indexOf("-get_layer_full") < t.log.indexOf("-run_jsx"), true);
+  assert.equal(t.log.indexOf("-screenshot_frame") < t.log.indexOf("-run_jsx"), true);
+});
+
+await check("a failing write still releases the lock", async () => {
+  const q = new WriteQueue();
+  const first = q.acquire("set_text").then((l) => {
+    try { throw new Error("AE said no"); } finally { l.release(); }
+  });
+  await assert.rejects(first, /AE said no/);
+  const second = await q.acquire("set_layer");
+  assert.equal(second.wait, null, "the lock must be free again, not merely reported free");
+  second.release();
+});
+
+// ---------------------------------------------------------------------------
+// Reporting the wait — only when there was one.
+// ---------------------------------------------------------------------------
+
+await check("an uncontended write reports no wait at all", async () => {
+  const q = new WriteQueue();
+  const lease = await q.acquire("create_comp");
+  assert.equal(lease.wait, null);
+  lease.release();
+});
+
+await check("a write that waited names what it waited behind, and for how long", async () => {
+  const q = new WriteQueue();
+  const t = tracer();
+  const [, waited] = await Promise.all([t.run(q, "run_batch", 60), t.run(q, "set_transform", 1)]);
+  assert.equal(waited.queuedBehind, "run_batch");
+  assert.ok(waited.waitedMs >= 40, `waitedMs was ${waited.waitedMs}`);
+});
+
+await check("the wait note merges into an object result", () => {
+  assert.deepEqual(mergeWait({ id: 7, ok: true }, { queuedBehind: "run_batch", waitedMs: 120 }), {
+    id: 7,
+    ok: true,
+    queuedBehind: "run_batch",
+    waitedMs: 120,
+  });
+});
+
+await check("the wait note never rewrites a shape it cannot own", () => {
+  // run_jsx returns whatever the caller's script returned. Folding fields into
+  // an array, a number or a string would change what every existing caller
+  // reads — those get a second content block instead (server.ts textResult).
+  const w = { queuedBehind: "run_batch", waitedMs: 1 };
+  assert.equal(mergeWait([1, 2, 3], w), null);
+  assert.equal(mergeWait(42, w), null);
+  assert.equal(mergeWait("done", w), null);
+  assert.equal(mergeWait(null, w), null);
+  assert.equal(mergeWait(false, w), null);
+  // …nor silently overwrite a key the op already uses.
+  assert.equal(mergeWait({ waitedMs: 9 }, w), null);
+});
+
+// ---------------------------------------------------------------------------
+// The long-batch hold — the actual gap the panel's own mutex leaves.
+// ---------------------------------------------------------------------------
+
+await check("a lease held for an async job blocks the next write until the job ends", async () => {
+  const q = new WriteQueue();
+  const jobs = new JobManager();
+  const order = [];
+
+  const batch = await q.acquire("run_batch");
+  jobs.register("j1", 600);
+  // Exactly what server.ts does when the panel answers with {jobId, async}.
+  batch.extendUntil(jobs.waitFor("j1", q.holdCeilingMs));
+  batch.release(); // the HTTP call is over; the batch is not.
+  order.push("envelope-returned");
+
+  const next = q.acquire("set_transform").then((l) => { order.push("next-ran"); l.release(); });
+
+  await sleep(30);
+  assert.deepEqual(order, ["envelope-returned"], "the next write must not run while the batch is still going");
+
+  jobs.complete("j1", { results: [] });
+  await next;
+  assert.deepEqual(order, ["envelope-returned", "next-ran"]);
+});
+
+await check("a job that fails still ends the hold", async () => {
+  const q = new WriteQueue();
+  const jobs = new JobManager();
+  const batch = await q.acquire("run_batch");
+  jobs.register("j2", 600);
+  batch.extendUntil(jobs.waitFor("j2", q.holdCeilingMs));
+  batch.release();
+  jobs.fail("j2", "op[3] blew up");
+  const next = await q.acquire("set_layer");
+  assert.equal(next.wait.queuedBehind, "run_batch");
+  next.release();
+});
+
+await check("a cancelled job ends the hold", async () => {
+  const q = new WriteQueue();
+  const jobs = new JobManager();
+  const batch = await q.acquire("run_batch");
+  jobs.register("j3", 600);
+  batch.extendUntil(jobs.waitFor("j3", q.holdCeilingMs));
+  batch.release();
+  // cancel_job is server-resident and takes no lock, which is the only reason
+  // this can happen at all.
+  assert.equal(isWriteOp("cancel_job"), false);
+  jobs.cancel("j3");
+  const next = await q.acquire("delete_layer");
+  next.release();
+});
+
+await check("await_job never blocks the queue", async () => {
+  // await_job is not a write, so it takes no lease. Modelled here as what the
+  // server actually does: wait on the JobManager while the batch's lease holds
+  // the lock, and prove the wait resolves rather than deadlocking.
+  const q = new WriteQueue();
+  const jobs = new JobManager();
+  const batch = await q.acquire("run_batch");
+  jobs.register("j4", 600);
+  batch.extendUntil(jobs.waitFor("j4", q.holdCeilingMs));
+  batch.release();
+
+  const awaited = jobs.waitFor("j4", 5000);
+  const queuedWrite = q.acquire("set_transform");
+  jobs.complete("j4", { results: [1] });
+
+  const state = await awaited;
+  assert.equal(state.status, "completed");
+  (await queuedWrite).release();
+});
+
+await check("the hold ceiling sits above the wait ceiling", () => {
+  // Otherwise a batch's hold could expire a beat before the writer queued
+  // behind it hits its own deadline, and the lock would be handed over
+  // mid-batch — the exact interleaving this is here to stop.
+  const q = new WriteQueue({ maxWaitMs: 1000 });
+  assert.ok(q.holdCeilingMs > 1000);
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation and backpressure
+// ---------------------------------------------------------------------------
+
+await check("a cancelled queued call never executes", async () => {
+  const q = new WriteQueue();
+  const ran = [];
+  const holder = await q.acquire("run_batch");
+
+  const ac = new AbortController();
+  const queued = q
+    .acquire("set_transform", ac.signal)
+    .then((l) => { ran.push("set_transform"); l.release(); });
+
+  ac.abort();
+  await assert.rejects(queued, (e) => e instanceof WriteQueueCancelledError);
+  holder.release();
+  await sleep(20);
+  assert.deepEqual(ran, [], "an aborted call must be dropped, not executed later");
+});
+
+await check("cancelling one queued call does not strand the ones behind it", async () => {
+  const q = new WriteQueue();
+  const ran = [];
+  const holder = await q.acquire("run_batch");
+  const ac = new AbortController();
+  const cancelled = q.acquire("a", ac.signal).then(() => ran.push("a"), () => {});
+  const survivor = q.acquire("b").then((l) => { ran.push("b"); l.release(); });
+  ac.abort();
+  holder.release();
+  await Promise.all([cancelled, survivor]);
+  assert.deepEqual(ran, ["b"]);
+});
+
+await check("a call cancelled before it ever queues is refused", async () => {
+  const q = new WriteQueue();
+  await assert.rejects(q.acquire("set_text", AbortSignal.abort()), (e) => e instanceof WriteQueueCancelledError);
+  // …and the queue is untouched by it.
+  const lease = await q.acquire("set_text");
+  assert.equal(lease.wait, null);
+  lease.release();
+});
+
+await check("the queue is bounded, and says so clearly", async () => {
+  const q = new WriteQueue({ maxDepth: 2 });
+  const holder = await q.acquire("run_batch");
+  const a = q.acquire("a");
+  const b = q.acquire("b");
+  await assert.rejects(q.acquire("c"), (e) => {
+    assert.ok(e instanceof WriteQueueFullError);
+    assert.match(e.message, /Nothing was written/);
+    assert.match(e.message, /run_batch/);
+    assert.match(e.message, /run_batch instead of as many calls/);
+    return true;
+  });
+  holder.release();
+  (await a).release();
+  (await b).release();
+});
+
+await check("waiting too long is reported as its own diagnosis, not as a bridge failure", async () => {
+  const q = new WriteQueue({ maxWaitMs: 30 });
+  const holder = await q.acquire("run_batch");
+  // The queue's own timers are unref'd — a write waiting on a batch must never
+  // be the reason a shutting-down process stays alive — so nothing here would
+  // hold the event loop open while we wait for that timer to fire.
+  const keepAlive = setTimeout(() => {}, 5000);
+  try {
+    await assert.rejects(q.acquire("set_transform"), (e) => {
+      assert.ok(e instanceof WriteQueueWaitError);
+      assert.match(e.message, /waited 0s behind `run_batch`/);
+      return true;
+    });
+  } finally {
+    clearTimeout(keepAlive);
+  }
+  holder.release();
+});
+
+await check("the three failure diagnoses share no remedy", () => {
+  const queued = new WriteQueueWaitError("set_transform", 600_000, "run_batch");
+  const timeout = new BridgeTimeoutError(7777, 300_000, { op: "run_batch" });
+  const unreachable = new BridgeUnreachableError(7777, new Error("ECONNREFUSED"));
+
+  // The bridge timeout forbids re-sending, because the call did reach AE and
+  // may still be running. The queue wait requires the opposite advice: the call
+  // never left the server, so re-sending is the correct move.
+  assert.match(timeout.message, /Do not re-send/i);
+  assert.match(queued.message, /re-sending this call is safe/i);
+  assert.match(queued.message, /nothing in the project was changed/i);
+  assert.match(queued.message, /neither a lost connection nor a busy bridge/i);
+  assert.match(queued.message, /AE_MCP_WRITE_QUEUE_WAIT_MS/);
+  assert.match(queued.message, /run_batch/, "it must name what it waited behind");
+
+  // And it must not be mistakable for either of the other two.
+  assert.doesNotMatch(queued.message, /Cannot reach the After Effects panel at/);
+  assert.doesNotMatch(queued.message, /did not answer within/);
+  assert.doesNotMatch(queued.message, /setup_panel/);
+  assert.doesNotMatch(timeout.message, /write queue/i);
+  assert.doesNotMatch(unreachable.message, /write queue/i);
+});
+
+// ---------------------------------------------------------------------------
+// The trap: the op timeout must be measured from execution, not from enqueue.
+//
+// Run against a real HTTP server on an ephemeral port so it goes through the
+// actual HttpClient/AbortSignal path rather than a re-implementation of it.
+// Never port 7777 — the live panel holds that.
+// ---------------------------------------------------------------------------
+
+const stub = http.createServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", async () => {
+    const { op } = JSON.parse(body || "{}");
+    await sleep(200);
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ ok: true, result: { echoed: op } }));
+  });
+});
+await new Promise((r) => stub.listen(0, "127.0.0.1", r));
+const stubPort = stub.address().port;
+assert.notEqual(stubPort, 7777, "must not bind the panel's port");
+
+await check("a queued call gets its full timeout budget, measured from execution", async () => {
+  // 700ms budget; the stub answers in 200ms. The call in front holds the lock
+  // for 900ms — well past the budget. If the clock started at enqueue, the
+  // queued call would blow its timeout having never run and report a bridge
+  // failure for a bridge that was answering fine.
+  process.env.AE_MCP_OP_TIMEOUT_MS = "700";
+  try {
+    const q = new WriteQueue();
+    const client = new HttpClient(stubPort);
+
+    const holder = await q.acquire("run_batch");
+    const queued = (async () => {
+      const lease = await q.acquire("set_transform");
+      try { return await client.runOp("set_transform", {}); }
+      finally { lease.release(); }
+    })();
+
+    await sleep(900);
+    holder.release();
+
+    const result = await queued;
+    assert.deepEqual(result, { echoed: "set_transform" });
+  } finally {
+    delete process.env.AE_MCP_OP_TIMEOUT_MS;
+  }
+});
+
+await check("the timeout still fires for a call that really is too slow", async () => {
+  process.env.AE_MCP_OP_TIMEOUT_MS = "50";
+  try {
+    const client = new HttpClient(stubPort);
+    await assert.rejects(client.runOp("set_transform", {}), (e) => e instanceof BridgeTimeoutError);
+  } finally {
+    delete process.env.AE_MCP_OP_TIMEOUT_MS;
+  }
+});
+
+await new Promise((r) => stub.close(r));
+
+console.log(`write-queue: ${passed} checks passed`);


### PR DESCRIPTION
Closes #55

## What this is

A per-session write queue in the MCP server. Every op classified `"write"` takes a FIFO mutex before it is forwarded to the panel; reads and server-resident ops never do. A call that waited says so — `queuedBehind: "<tool>"`, `waitedMs: n` — exactly as the issue asks, and only when it actually waited.

## Diagnosis: where the interleaving actually comes from

The brief was right to ask. **The panel's `evalScript` mutex is real and it is not the gap.**

`packages/ae-panel/client/main.js` chains every `cs.evalScript` on `__evalChain`, so two ordinary writes cannot interleave *within* one op — `dispatch()` opens its undo group and closes it before the next call gets a turn. Two concurrent `set_transform`s were never the bug.

The gap is **`run_batch` past its 500-op inline cutoff**:

- `packages/jsx/batch.jsx` calls `app.beginUndoGroup(name)`, sets `JOBS[jobId].undoOpen = true`, and returns `{jobId, async:true}` **immediately**, with the group still open.
- The panel's `driveJob()` then calls `_continue_job` in chunks of 25, `setTimeout(r, 0)` between them. Each chunk is a **separate** `evalScript` and therefore its own turn on the chain.
- So any op issued meanwhile slots in *between two chunks*. AE's undo groups do not nest, so that op's own `endUndoGroup()` (from `withUndo` in `core.jsx`) **closes the batch's group**. The rest of the batch writes outside any group, and the batch's final `endUndoGroup()` closes whatever is open by then.

One user action, an arbitrary number of undo steps, and no error anywhere. That is the reported symptom, and it is why "the panel already handles it" was not an answer.

There is a second, smaller problem the queue also fixes: **ordering**. Requests arrive at the server in the order the agent issued them, but the old code fired every one at `fetch` in parallel and took whatever order the sockets delivered. Two writes where the second depends on the first were a coin toss.

## Design notes

- **Classification is a table with no default.** `OpMutation` in `packages/shared/src/schemas.ts`, keyed by op name, `"write" | "read" | "server"`, `satisfies Record<OpName, …>`. `tests/unit/write-queue.mjs` fails the build when an op is in `OpSchemas` and not the table, or the other way round, or when `SERVER_OPS` and the `"server"` bucket disagree. `isWriteOp()` falls back to `"write"` at runtime, so even a shipped omission costs serialization rather than correctness.
- **The lease outlives its own call.** `extendUntil` is the actual fix: when `run_batch` answers with a jobId, the lock is held until `JobManager` reports the job done. Releasing at the HTTP response would leave exactly the gap above. A leak guard at **twice** the wait ceiling covers a job that never reports (dropped WS) — set above the wait ceiling so any writer queued behind the batch has hit its own deadline and gone before the hold could expire and hand it the lock mid-batch.
- **No deadlock.** `await_job`, `get_job` and `cancel_job` are `"server"`, never queued. The job driver runs in the panel and asks the server for nothing. There is no cycle.
- **The timeout trap.** `AbortSignal.timeout` is created inside `runOp`, and `acquire()` is awaited before it, so the op budget starts at execution and not at enqueue. Pinned by a test that runs the real `HttpClient` against a stub HTTP server on an ephemeral port.
- **A third diagnosis, not a third variant of the second.** `WriteQueueWaitError` says the call never left the server, nothing was written, and re-sending once the queue drains is correct — the *opposite* of `BridgeTimeoutError`, which forbids re-sending because that call did reach AE. It also must not send anyone to `check_setup`, since the bridge is fine. A test asserts the three share no remedy and that neither bridge error mentions the queue.
- **Cancellation.** An MCP request cancelled while queued rejects out of `acquire` and never reaches the bridge. Cancelling one waiter does not strand the ones behind it.
- **Bounded.** `AE_MCP_WRITE_QUEUE_DEPTH` (64) and `AE_MCP_WRITE_QUEUE_WAIT_MS` (600s), both with a clear error naming what is in front.
- **Where the note attaches.** Merged into the result object where there is one. `run_jsx` returns whatever the caller's script returned — arrays, numbers, strings — so those get a **second text content block** instead; #43 is the standing reminder that changing what a `run_jsx` answer looks like is expensive. Vision results never carry a note at all, since screenshots are reads, so the image envelope is untouched.

## Verified offline

`npm run build` and `npm test` pass. 35 new checks across two files:

**`tests/unit/write-queue.mjs` (29)** — classification completeness in both directions and against `SERVER_OPS`; the named read/write/server exemptions; two concurrent writes strictly in sequence; issue order preserved across four; reads overlapping a write; a throwing write still releasing; `waitedMs`/`queuedBehind` absent when uncontended and correct when not; `mergeWait` refusing arrays, numbers, strings, null and key collisions; the async-job hold blocking the next write until complete/failed/cancelled; `await_job` resolving while the batch's lease is held; hold ceiling above wait ceiling; a cancelled queued call never executing; cancellation not stranding the queue; bounded depth; the wait error's message; the three diagnoses sharing no remedy; and the timeout measured from execution against a real stub bridge.

**`tests/unit/write-queue-server.mjs` (6)** — the real MCP server over an in-memory transport against a stub HTTP+WS bridge on an ephemeral port: two concurrent writes reaching the bridge one at a time with the note on the second only; a read overlapping a slow write and carrying no note; a non-object `run_jsx` result keeping its shape with the note in a second block; an uncontended write byte-identical to before; a long batch holding the queue until the WS `complete` event arrives; and `await_job` answering while that lease is held.

No test binds 7777, and none of them touch After Effects.

## UNVERIFIED — After Effects was not available

The machine was driving a live AE session on someone's real project throughout, so **nothing here has been run against After Effects.** Specifically unverified:

- That holding the lease across a long `run_batch` actually produces one undo step in AE's Edit menu where the old code produced several. The mechanism is read off `batch.jsx` and `main.js` rather than observed.
- That `driveJob`'s WS `complete` event fires in the real panel at the moment the JSX side closes the undo group. The stub sends it on cue; the real panel's timing is inferred from `driveJob`.
- That serializing `set_active_comp` and `export_mogrt` (both classified `"write"`) causes no practical slowdown in a real session.
- Whether the 600s default wait ceiling is generous enough for the largest batches the user actually runs. It is a guess, changeable by env var.

## Manual verification (CLAUDE.md recipe 21, added in this PR)

1. Issue `create_solid_layer` and `create_text_layer` on the same comp in one turn. The second result should carry `queuedBehind: "create_solid_layer"` and a `waitedMs`; the first should carry neither.
2. The real one: `run_batch` with 600 ops (past the 500 inline cutoff) and, in the **same** turn, a `set_transform`. The batch returns `{jobId}` immediately; the `set_transform` must not return until the job does. Afterwards AE's Edit menu should show the batch as **one** undo step, with the transform as a separate step after it. Before this landed the transform went in mid-batch and the batch broke into an arbitrary number of steps.
3. Controls: `list_layers` issued alongside the running batch returns straight away, and `await_job` on the batch resolves rather than hanging — it would hang if it queued.

## Merge hygiene

- **`OpMutation` needs a line per new op.** It is appended at the very end of `schemas.ts`, after `OpName`, so it conflicts as little as possible with the other branches adding schemas mid-file. If you merge a PR that adds an op and skip this table, `npm test` fails with the op named and the three buckets explained — that is deliberate, and it is the only thing keeping the classification honest. The table carries a boxed comment saying so.
- `server.ts` changes are additive and localised: one import, `export` on the existing `SERVER_OPS` const, a new `isWriteOp()`, one `const writes = new WriteQueue()`, an acquire block before `bridge.runOp`, an optional second parameter on `textResult`, and a `finally`. Nothing reformatted or re-sorted.
- `errors.ts` changes are three new classes appended after `AeError`. Nothing existing touched.
- One CI step added after the ExtendScript block.

## Not done, deliberately

- **The guidance was not touched.** `src/guides/`, `src/prompts/`, `src/generated/content.ts`, `plugin/` and `GUIDE_TOPICS` belong to another agent's PR. **They now over-warn**: the rule telling agents never to issue two AE-writing calls concurrently is no longer necessary, and batching independent writes is now a legitimate way to save round-trips. That should be relaxed in the guidance PR or a follow-up — and the same applies to the user's own project instructions.
- **No tool description mentions the queue.** `queuedBehind`/`waitedMs` are self-explanatory where they appear, and `descriptions.ts` is being edited on several other branches.
- **Nothing in the panel changed.** The fix is entirely server-side, so no panel reinstall and no AE restart is needed for it — which matters given the version gate.
- **Cross-process serialization is out of scope.** The queue is per-server-process, so a second MCP client pointed at the same panel is not serialized against the first. Noted in CLAUDE.md rather than solved; a real fix belongs in the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
