### PR TITLE
feat(comps): snapshot_comp/diff_comp and duplicate_comp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 | `packages/jsx/*.jsx` | ExtendScript handlers. Each module attaches functions to the global `OPS` table. ES3-ish — no `let`/`const`/arrow/templates. |
 | `packages/jsx/core.jsx` | JSON polyfill, `dispatch(payloadJson)` router, `withUndo()` wrapper, `JOBS` table for chunked async. |
 | `packages/jsx/explore.jsx` | `get_layer_full` — the deep one-shot dump. The whole reason this MCP exists. Spend disproportionate care here. |
+| `packages/jsx/snapshot.jsx` | The comp fingerprint and the diff of two of them. Backs `snapshot_comp` / `diff_comp` and the `diff:true` flag on `run_jsx` / `run_batch`. The diff is pure — two objects in, one out — which is what lets it be tested with no AE. |
 | `packages/jsx/batch.jsx` | `run_batch` for ≤100 ops inline; otherwise registers a job and yields chunks via `_continue_job`. |
 | `packages/jsx/vision.jsx` | `saveFrameToPng` wrapper. Returns a temp path; the panel base64-encodes. |
 | `packages/jsx/footage.jsx` | `import_footage` / `create_footage_layer`. The SVG viewBox check lives here because import is the only place that has the file path and the resulting item together. |
@@ -60,6 +61,7 @@ The MCP server is stateless except for an in-memory `JobManager`. The panel is t
 | `packages/mcp-server/src/tools/descriptions.ts` | All tool descriptions in one file — including the verbatim screenshot guidance. |
 | `packages/mcp-server/src/bridge/{httpClient,wsClient,discovery}.ts` | Bridge plumbing. |
 | `packages/mcp-server/src/jobs/manager.ts` | In-memory job table, `waitFor(jobId)` for the `await_job` tool. |
+| `packages/mcp-server/src/snapshots/store.ts` | In-memory comp fingerprints for `snapshot_comp` / `diff_comp`. Bounded ring; `missingMessage()` is the whole reason it is a class rather than a `Map`. |
 | `packages/mcp-server/src/issues/journal.ts` | The cross-session issue journal at `<project>/.ae-mcp/issues/`. Backs `log_issue` / `list_known_issues` / `mark_issue_reported`. The project folder is `process.cwd()`; a client that gives no usable one (Claude Desktop starts servers at `/`) falls back to `~/.after-effects-mcp`, reported as `scope: "home"` so the fallback is never silent. `AE_MCP_HOME` overrides the root (used by the CI check). |
 | `packages/mcp-server/src/setup/{check,install,paths}.ts` | Backs `check_setup` / `setup_panel`. Never touches the bridge — it exists for the case where the panel isn't installed yet. |
 | `packages/mcp-server/src/setup/platform.ts` | **The only place macOS and Windows diverge** (PlayerDebugMode storage, AE process detection). Plus `cepExtensionsDir()` in `paths.ts`. Keep platform branching here — do not scatter `process.platform` through the codebase. |
@@ -97,6 +99,7 @@ The `server.ts` tool registration loop reads `OpSchemas`, so no MCP-side wiring 
 - **Vision** (`screenshot_frame`, `screenshot_layer`): JSX returns `{path, width, height, time, compId, layerId?}`. Panel reads the PNG, normalises it to 8-bit, base64-encodes, returns `{base64, bytes, ...}`. Server packages as MCP `image` content block. Two outcomes are deliberately *not* images: a fully transparent frame comes back as `{empty:true, reason}` and goes through `textResult`, and a frame whose pixels match a different earlier request is refused as a `STALE_FRAME` error. See "Known fragile areas".
 - **Long batch** (`run_batch` >100 ops): JSX returns `{jobId, async:true, total}`. Panel drives `_continue_job` in chunks of 25 in the background, broadcasting `progress` events on WS. Server forwards WS progress as `notifications/progress` keyed by the request's `progressToken`.
 - **Server-resident** (`await_job`, `get_job`, `cancel_job`, `check_setup`, `setup_panel`, `init_project`, `ae_guide`, `log_issue`, `list_known_issues`, `mark_issue_reported`): handled in `server.ts`; never forwarded to the panel (except `cancel_job`, which also sends `_cancel_job` to the bridge to set the JSX-side flag). They're still listed in `OpSchemas` so `tools/list` picks them up — membership in `SERVER_OPS` is what stops the forwarding.
+- **Half server-resident** (`snapshot_comp`, `diff_comp`): the panel gathers, the server remembers. `SNAPSHOT_OPS` in `server.ts` routes them to `runSnapshotOp`, which forwards an internal read op (`_comp_fingerprint` / `_comp_diff`) and keeps the answer in `SnapshotStore`. Deliberately *not* in `SERVER_OPS` — unlike those, these do touch the bridge, and they are dispatched from inside the same `try` as `bridge.runOp` so the timeout, `AeError` and Unknown-op mappings all apply unchanged.
 - **Prose** (`ae_guide`): returns the markdown as a bare text content block rather than through `textResult()`. JSON-stringifying it would hand the model a wall of `\n`.
 - **Downsampled screenshots**: handled entirely in `vision.jsx`. `saveFrameToPng` *does* respect `CompItem.resolutionFactor` (measured: a 3840×2160 comp yields 1920×1080 at factor 2, 960×540 at factor 4), so `__saveFrameAt` sets the factor, renders, and restores it in a `finally`. That restore is not optional — a throw mid-render would otherwise leave the user's comp at reduced resolution. The panel reads the true dimensions out of the PNG's IHDR chunk rather than computing them, so reported size can never disagree with the image sent. An earlier version shelled out to `sips`; it was replaced because rendering smaller is faster than resampling and needs no external tool, which is what makes downsampling work on Windows. The factor is *derived* from the comp when the caller omits one (`__autoDownsample`, aiming at a ~1280px long edge) — which is why `ScreenshotFrame`/`ScreenshotLayer` must not carry a zod `.default(1)`: a default there would reach the panel as an explicit 1 and the derivation would never run.
 
@@ -241,6 +244,60 @@ The costs, both reported rather than worked around:
   to replace an existing one. It is not a patch, and quietly half-rewriting
   someone's hand-written style guide is worse than refusing.
 
+## Comp snapshots, and why they live in the server
+
+Verifying a write used to mean reading the comp back — `list_layers`, then
+`get_layer_full` — and comparing by eye. That answer is thousands of tokens,
+and a tool result is re-sent on every later request for the rest of the session,
+so a fourteen-scene build paid for it over and over (issue #52). A fingerprint
+plus a diff is a few dozen tokens for the same three questions: which layer is
+the new one after a `copyToComp` (copies do not land at index 1), where a
+partly-applied `run_jsx` stopped, and whether an assembly landed when
+`screenshot_frame` cannot render it.
+
+**The snapshot is kept in the MCP server, not in the After Effects project.**
+That split is the whole design. Only the panel can read AE, so the gathering
+has to happen there; but writing the fingerprint into the .aep would make a
+*read* tool modify the user's project — a project-panel item or a marker they
+never asked for, in their file and in their undo stack, for scaffolding nobody
+wants to keep. `SnapshotStore` is the other half: the one place in this server
+that remembers anything besides `JobManager`.
+
+The cost is a lifetime of one process, which for a stdio client is one session.
+That is acceptable — nothing needs yesterday's snapshot — but it must never be
+met as a cryptic failure, so `missingMessage()` says why the id is gone, lists
+the ids that *are* held, and names both ways forward (take a fresh one; or read
+the comp back, since a diff can only compare against a snapshot taken
+beforehand). That method is why the store is a class rather than a `Map`.
+
+Three further things hold this honest:
+
+- **`diff:true` on `run_jsx` / `run_batch` fingerprints inside the same call.**
+  A before-snapshot taken by a separate `snapshot_comp` is a second round-trip
+  during which anything can happen, and the agent has to remember to make it. So
+  the before, the write and the after are one bridge call, and the diff logic
+  lives in `snapshot.jsx` where `raw.jsx` and `batch.jsx` can both reach it —
+  each of them gains about six lines and no new contract.
+- **A failed write still gets its diff.** Nothing rolls back, so "where did it
+  stop" is the most valuable question after a throw. `__diffAnnotateError`
+  *mutates* the error's `message` and rethrows the same object, so `line` and
+  `stack` survive for `__mkError` — never build a new Error there.
+- **A diff is the extreme case of a scoped read, so it says what it left out.**
+  `covers` travels with every diff and `snapshot_comp` returns the long form:
+  the fingerprint records ids, names, indices, types, in/out/start, parent,
+  enabled, per-property keyframe counts, expression count and effect count, and
+  no property *values*, expression text, effect parameters, masks or shape
+  contents. Reading "no differences" as "identical" is the failure mode, and it
+  is the same class of lie as a swallowed error. The walk stops there on purpose
+  — a fingerprint that costs as much as the read it replaces is worth nothing —
+  and `tests/unit/comp-snapshot.mjs` puts probes on the effect and shape
+  accessors so a later edit cannot quietly start walking them.
+
+`index` is recorded but never diffed directly: inserting one layer shifts every
+index below it, which would report twenty changed layers for one addition.
+Relative order is compared separately, so a real reorder is reported and an
+insertion is not.
+
 ## Build + run
 
 ```bash
@@ -285,6 +342,10 @@ That sync is **opt-in on purpose**. The installed bundle is one half of the pane
 18. `export_mogrt` on a comp with a text layer in a non-Adobe font → returns in a few seconds with no dialog in AE, and `fonts` names the font. With `suppressDialogs:false` → a modal dialog appears and the call blocks until it is clicked; that is the control, and it is worth running once because the whole tool rests on it. Called twice with the same `name` → refuses the second, then replaces with `overwrite:true`. On a project that has never been saved → refuses with a message naming the save, not a dialog.
 19. `.mogrt` thumbnail: give the comp an empty first frame (keyframe every layer's opacity 0 → 100 over the first second), export with no `posterTime` → `thumb.png` inside the zip is solid black. Export again with `posterTime` past the fade → `thumbnail.patched: true` and the frame is in there at AE's own thumbnail dimensions. Unzip and check the *other* entries are byte-identical; a corrupt `project.aegraphic` would not show up in the picture.
 20. Shape reads, on a shape layer with several groups: `get_layer_full({compId, layerId, include:["shape"]})` → no `ADBE Vector Materials Group` anywhere, `materialsOmitted` counting the groups it was dropped from, and every group whose Transform nobody has touched carrying `atDefaults: true` instead of its seven properties. With `shapeMaterials:true` → the 48 properties are back and `materialsOmitted` is gone. A group that is scaled, keyframed or expression-driven must *never* say `atDefaults`. With `shapeDetail:"compact"` → one indented line per group, `[n keys]`/`[expr]` on the animated properties, and a path as `path(7 verts, closed)`. Measured on the layer in issue #42: 13,369 → 3,052 → 643 characters of shape JSON.
+
+21. `snapshot_comp({compId})` on a comp with a few layers → a `snapshotId` and a handful of fields, **no fingerprint** (add `includeFingerprint:true` to see it). Add a layer and keyframe its Opacity, then `diff_comp({since})` → the new layer's id and name, `layer N Opacity keys 0 → 4`, `unchangedLayers` counting the rest, and nothing at all about them. `diff_comp` again immediately → `changeCount: 0` and a summary that says the recorded fields did not move rather than "identical". Reorder two layers → `reordered` names those two; add a layer at the top instead → **no** `reordered` and no `changed`, even though every index below it shifted. `diff_comp({since:"snap_999"})` → the store's message, naming the ids it does hold. Restart the MCP server and reuse an old id → the same message, not a crash.
+22. `diff:true` on the write ops: `run_jsx({code:"…create three layers…", diff:true})` → `{ok, returned, diff}` with the three ids, in one call. The same script with a deliberate throw half-way → the error message carries `|| Changed before it stopped: 1 layer added…` **and** still reports its line number. `run_batch({ops:[…], diff:true})` across two comps → a `comps` array with one diff each. With no `compId` anywhere in the call and no comp open in the viewer → `diff.unavailable` naming `diffCompId`, and the call itself unaffected.
+23. `duplicate_comp({compId})` on a comp with a precomp layer → new id, name `<name> 2`, and the copy's precomp layer resolves to the **same** nested comp as the original (that is the shallow contract; the result says so). The same call with `deep:true` → the copy points at its own nested comp, editing that one leaves the original alone, and a nested comp used by three layers is duplicated **once** with all three re-pointed at it. `folderId` pointing at a comp instead of a folder → refused, naming the id and what it actually is, with nothing created. `nameSuffix:" [v2]"` where `<name> [v2]` already exists → the copy gets `… [v2] 2`, and the existing item keeps its name.
 
 16. Compiled binary, the one no unit test reaches: run the built binary from an empty directory *and* from `/`, and confirm `setup_panel` installs a populated `node_modules/ws`. Under `bun --compile` the module resolver returns a bare specifier rather than throwing, so this path cannot be exercised under plain Node — see the `require.resolve` note in Known fragile areas.
 
@@ -341,6 +402,20 @@ The user-facing half is the offer to report. It now lives in exactly two places:
 - **The `.mogrt` filename comes from `comp.motionGraphicsTemplateName`, not the comp name**, and it defaults to the literal `"Untitled"` for a template assembled by script. Left alone, every export in a project overwrites the same `Untitled.mogrt`. `export_mogrt` defaults it to the comp name but leaves a name the user actually set alone. Related: `CompItem.posterTime` does not exist (the thumbnail is the comp's first frame, hence the black one on anything that fades up), and there is no `getMotionGraphicsDataName` — only the reverse-indexed `setMotionGraphicsControllerName`.
 - **AE fabricates dimensions for an SVG with a very large viewBox, and the numbers depend only on the viewBox.** A synthetic file with the reported `0 0 278050 333334` imports as **15906x5654** — byte for byte the dimensions in issue #33, from an entirely different SVG. It will not even rasterize: `saveFrameToPng` on a comp containing one produces no file at all, where a healthy SVG renders in seconds. That reproducibility is what makes the aspect-ratio check in `footage.jsx` a reliable detector rather than a heuristic.
 - **CEP anchors `__dirname` at the extension root, not at the folder holding the file.** So `require("ws")` resolves (node_modules is at the root) while `require("./pngcodec.js")` from `client/main.js` does not — it looks for `<ext>/pngcodec.js`, which is not where the file is. This is why the panel is the only part of the system whose bootstrap has to be tested rather than reasoned about: it shipped on `versions/0.3.0` refusing to start with "cannot start — pngcodec.js … is missing", and nothing caught it, because there is no AE on a runner, the unit tests require those modules by absolute path, and the one machine it had ever run on still had a pre-#36 panel installed. **Resolve panel-internal paths from `cs.getSystemPath(SystemPath.EXTENSION)`, never from `__dirname`** — that is authoritative, and `main.js` now builds `clientDir` from it before requiring anything. `tests/unit/panel-boot.mjs` runs the real `main.js` against a stub CEP host in a copy of the installed layout and asserts it reaches a listening `/health`.
+- **`CompItem.duplicate()` is shallow, and the copy looks finished.** The
+  duplicate's precomp layers point at the *same* nested comps as the original,
+  so "make a variant of this rig" and then editing the variant edits the
+  original too — silently, and usually noticed several scenes later.
+  `duplicate_comp` keeps that as the default because it is AE's own Duplicate
+  and changing it would surprise anyone who knows the app, but it says so in the
+  result rather than leaving it to be discovered, and `deep:true` duplicates the
+  nested comps and re-points the copy at them. Two things `deep` has to get
+  right and a hand-rolled `run_jsx` version usually does not: the same nested
+  comp appears on several layers, so it is duplicated once and reused (keyed by
+  the *original* id) rather than fanned out per reference; and the copy is
+  registered in that map *before* the walk descends into it, which is what makes
+  a cycle terminate. A nested duplication that fails part-way names every comp
+  it created in the error — the objects are real and nothing rolled them back.
 - **CEP returns a file URL, not a path.** `getSystemPath` gives `file:///C:/Users/…` on Windows, so stripping only the scheme leaves `/C:/…`; `path.join` then reads it as root-relative and produces `\C:\…\bundle.jsx`, and the panel reports the bundle missing while it sits at that exact location. `client/csinterface.js` strips the slash before a drive letter — do that there, not at call sites, since it is the one place a URL becomes a native path. `tests/unit/panel-paths.mjs` covers it; there is no AE on a runner, so nothing else does.
 
 ## Platform notes

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "uninstall:panel": "node scripts/uninstall-panel.mjs",
     "doctor": "node scripts/doctor.mjs",
     "diagnose:spaces": "node scripts/diagnose-spaces.mjs",
-    "test": "node tests/unit/panel-version.mjs && node tests/unit/panel-paths.mjs && node tests/unit/panel-install.mjs && node tests/unit/panel-boot.mjs && node tests/unit/bridge-timeout.mjs && node tests/unit/png-codec.mjs && node tests/unit/frame-cache.mjs && node tests/unit/mogrt-thumbnail.mjs && node tests/unit/issue-journal.mjs && node tests/unit/jsx-ternary.mjs && node tests/unit/jsx-undo-group.mjs && node tests/unit/run-jsx-result.mjs && node tests/unit/shape-read.mjs && node tests/unit/parent-transform.mjs && node tests/unit/svg-import.mjs && node tests/unit/bundle-determinism.mjs",
+    "test": "node tests/unit/panel-version.mjs && node tests/unit/panel-paths.mjs && node tests/unit/panel-install.mjs && node tests/unit/panel-boot.mjs && node tests/unit/bridge-timeout.mjs && node tests/unit/png-codec.mjs && node tests/unit/frame-cache.mjs && node tests/unit/mogrt-thumbnail.mjs && node tests/unit/issue-journal.mjs && node tests/unit/jsx-ternary.mjs && node tests/unit/jsx-undo-group.mjs && node tests/unit/run-jsx-result.mjs && node tests/unit/shape-read.mjs && node tests/unit/parent-transform.mjs && node tests/unit/svg-import.mjs && node tests/unit/bundle-determinism.mjs && node tests/unit/comp-snapshot.mjs && node tests/unit/duplicate-comp.mjs",
     "new:project": "node packages/mcp-server/dist/index.js init",
     "start": "node packages/mcp-server/dist/index.js",
     "inspect": "npx @modelcontextprotocol/inspector node packages/mcp-server/dist/index.js",

--- a/packages/jsx/batch.jsx
+++ b/packages/jsx/batch.jsx
@@ -5,6 +5,9 @@ OPS.run_batch = function (args) {
   var ops = args.ops || [];
   var transactional = args.transactional !== false;
   var name = args.undoGroupName || "AE MCP Batch";
+  // diff:true fingerprints the comps this batch names, before and after, inside
+  // this one call — see snapshot.jsx. Null unless asked for.
+  var diffState = __diffStart(args, ops);
   // Short batches: run inline synchronously. Inline stays sub-second for
   // typical create/keyframe ops up to a few hundred; the async-job overhead
   // (jobId envelope, polling, progress notifications) is only worth it for
@@ -19,10 +22,18 @@ OPS.run_batch = function (args) {
         results.push(handler(step.args || {}));
       } catch (e) {
         errors.push({ index: i, op: step.op, error: e.message });
-        if (transactional) throw new Error("Batch failed at op[" + i + "] " + step.op + ": " + e.message);
+        if (transactional) {
+          // Nothing rolls back, so the half-applied state is what the caller
+          // has to reason about. The diff says where it stopped.
+          var failure = new Error("Batch failed at op[" + i + "] " + step.op + ": " + e.message);
+          __diffAnnotateError(failure, diffState);
+          throw failure;
+        }
       }
     }
-    return { results: results, errors: errors, total: ops.length };
+    var out = { results: results, errors: errors, total: ops.length };
+    if (diffState) out.diff = __diffFinish(diffState);
+    return out;
   }
   // Long batches: register job, return jobId; panel polls _continue_job.
   var jobId = __newJobId();
@@ -35,6 +46,9 @@ OPS.run_batch = function (args) {
     cancelled: false,
     transactional: transactional,
     name: name,
+    // Carried across the chunked continuations: the before-fingerprint has to
+    // outlive the call that took it, or a long batch could never be diffed.
+    diffState: diffState,
   };
   // Wrap async run already inside an undoGroup chain. We open it now, the
   // continuations stay inside it until finalization.
@@ -68,13 +82,19 @@ OPS._continue_job = noUndo(function (args) {
         if (j.undoOpen) { app.endUndoGroup(); j.undoOpen = false; }
         // Attempt rollback via undo
         try { app.executeCommand(app.findMenuCommandId("Undo")); } catch (e2) {}
-        return { done: true, failed: true, jobId: jobId, error: e.message, atIndex: j.cursor, results: j.results, errors: j.errors };
+        var failed = { done: true, failed: true, jobId: jobId, error: e.message, atIndex: j.cursor, results: j.results, errors: j.errors };
+        // Taken after the undo attempt, so it reports the state that actually
+        // survived rather than the one before AE was asked to back it out.
+        if (j.diffState) failed.diff = __diffFinish(j.diffState);
+        return failed;
       }
     }
   }
   if (j.cursor >= j.total) {
     if (j.undoOpen) { app.endUndoGroup(); j.undoOpen = false; }
-    return { done: true, jobId: jobId, results: j.results, errors: j.errors, total: j.total };
+    var done = { done: true, jobId: jobId, results: j.results, errors: j.errors, total: j.total };
+    if (j.diffState) done.diff = __diffFinish(j.diffState);
+    return done;
   }
   return { done: false, jobId: jobId, progress: j.cursor, total: j.total };
 });

--- a/packages/jsx/comps.jsx
+++ b/packages/jsx/comps.jsx
@@ -77,6 +77,155 @@ OPS.delete_comp = function (args) {
   return { ok: true };
 };
 
+// ---------------------------------------------------------------------------
+// duplicate_comp
+// ---------------------------------------------------------------------------
+// There was duplicate_layer, create_comp and delete_comp but no way to copy a
+// comp, so every rig workflow detoured through run_jsx and CompItem.duplicate()
+// (issue #54). Two things that detour never got right:
+//
+//   * AE's own Duplicate is SHALLOW. The copy's precomp layers point at the
+//     same source comps as the original, so "make a variant of this rig" and
+//     then editing the variant edits the original too. `deep:true` duplicates
+//     the nested comps as well and re-points the copy's layers at them, which
+//     is the entire value of the flag.
+//   * The same nested comp usually appears on several layers. Duplicating per
+//     layer fans out one copy per reference; __dupNested keeps a map from
+//     original id to its copy and reuses it, and registers the copy *before*
+//     recursing so a cycle terminates instead of recursing for ever.
+
+// AE happily allows two project items with the same name, which makes a
+// deep-duplicated rig unreadable in the project panel. Appending a counter is
+// the smaller evil, and the chosen name is reported either way.
+function __dupNameTaken(name) {
+  for (var i = 1; i <= app.project.numItems; i++) {
+    if (app.project.item(i).name === name) return true;
+  }
+  return false;
+}
+
+function __dupUniqueName(base) {
+  if (!__dupNameTaken(base)) return base;
+  for (var n = 2; n < 1000; n++) {
+    var candidate = base + " " + n;
+    if (!__dupNameTaken(candidate)) return candidate;
+  }
+  return base;
+}
+
+// Depth is a backstop, not the cycle guard — `seen` is. AE refuses to nest a
+// comp inside itself, but nothing here should recurse for ever if a future
+// build ever allows it.
+var __DUP_MAX_DEPTH = 32;
+
+function __dupNested(src, opts, depth) {
+  var key = "C" + src.id;
+  if (opts.seen.hasOwnProperty(key)) return opts.seen[key];
+  if (depth > __DUP_MAX_DEPTH) {
+    throw new Error("nested comps are more than " + __DUP_MAX_DEPTH + " deep below the comp being duplicated");
+  }
+  var srcId = src.id;
+  var srcName = src.name;
+  var dup = src.duplicate();
+  opts.seen[key] = dup;
+  if (opts.nameSuffix) dup.name = __dupUniqueName(srcName + opts.nameSuffix);
+  opts.created.push({ fromCompId: srcId, fromName: srcName, compId: dup.id, name: dup.name });
+  __dupRepoint(dup, opts, depth);
+  return dup;
+}
+
+// Re-point every precomp layer of a freshly duplicated comp at the duplicate of
+// its source rather than the original. Layers whose source is footage, and
+// layers with no source at all, are left alone.
+function __dupRepoint(comp, opts, depth) {
+  for (var i = 1; i <= comp.numLayers; i++) {
+    var l = comp.layer(i);
+    if (!(l instanceof AVLayer)) continue;
+    var srcItem = null;
+    try { srcItem = l.source; } catch (e) { continue; }
+    if (!srcItem || !(srcItem instanceof CompItem)) continue;
+    var replacement = __dupNested(srcItem, opts, depth + 1);
+    // fixExpressions:false — the layer keeps its name and its own properties,
+    // so there is nothing for AE to rewrite, and letting it rewrite expressions
+    // on a rig is a change nobody asked for.
+    l.replaceSource(replacement, false);
+    opts.repointed += 1;
+  }
+}
+
+OPS.duplicate_comp = function (args) {
+  var src = getCompById(args.compId);
+  var folder = null;
+  if (args.folderId !== undefined && args.folderId !== null) {
+    var f = app.project.itemByID(args.folderId);
+    if (!f) throw new Error("No project item with id " + args.folderId + " to use as folderId");
+    if (!(f instanceof FolderItem)) {
+      throw new Error(
+        "folderId " + args.folderId + ' ("' + f.name + '") is a ' + __itemKind(f) +
+        ", not a project folder. Pass the id of a folder from get_project_summary, or omit folderId."
+      );
+    }
+    folder = f;
+  }
+
+  var opts = { seen: {}, created: [], repointed: 0, nameSuffix: null };
+  if (args.nameSuffix) opts.nameSuffix = args.nameSuffix;
+
+  // Captured as primitives before the duplicate. Some AE calls invalidate every
+  // handle held across them (exportAsMotionGraphicsTemplate is the measured
+  // one), so nothing below reads `src` again.
+  var srcId = src.id;
+  var srcName = src.name;
+  var dup = src.duplicate();
+  var newId = dup.id;
+  if (args.name) dup.name = args.name;
+
+  if (args.deep) {
+    opts.seen["C" + srcId] = dup;
+    try {
+      __dupRepoint(dup, opts, 1);
+    } catch (e) {
+      // The copy and any nested copies made before the failure are real and
+      // nothing rolled them back. Reporting {ok:true} over a half-built rig, or
+      // an error that does not name what exists, are the same class of lie.
+      var madeIds = [];
+      madeIds.push(String(newId));
+      for (var m = 0; m < opts.created.length; m++) madeIds.push(String(opts.created[m].compId));
+      throw new Error(
+        "duplicate_comp deep failed part-way: " + e.message +
+        ". These comps were created and still exist: ids " + madeIds.join(", ") +
+        ". Undo once in After Effects to back the whole thing out, or delete_comp them."
+      );
+    }
+  }
+
+  // Re-fetch by id rather than trusting the handle held across the duplication.
+  var made = app.project.itemByID(newId);
+  if (!made) throw new Error("duplicate_comp created comp " + newId + " but it could not be read back");
+  if (folder) made.parentFolder = folder;
+
+  var out = __compSummary(made);
+  out.fromCompId = srcId;
+  out.fromName = srcName;
+  out.deep = !!args.deep;
+  if (folder) {
+    out.folderId = folder.id;
+    out.folderName = folder.name;
+  }
+  if (args.deep) {
+    out.nestedDuplicated = opts.created;
+    out.nestedCount = opts.created.length;
+    out.layersRepointed = opts.repointed;
+    if (opts.created.length === 0) {
+      out.note = "deep:true had nothing to do - this comp has no precomp layers.";
+    }
+  } else {
+    out.note = "Shallow copy: its precomp layers still point at the SAME nested comps as the original, " +
+      "so editing one of those edits both. Pass deep:true to duplicate the nested comps too.";
+  }
+  return out;
+};
+
 OPS.set_active_comp = function (args) {
   var c = getCompById(args.compId);
   c.openInViewer();

--- a/packages/jsx/raw.jsx
+++ b/packages/jsx/raw.jsx
@@ -133,5 +133,13 @@ OPS.run_jsx = noUndoWhen(function (args) { return args.undoGroup === false; }, f
   // name mirrors dispatch()'s default ("AE MCP: " + op); false means the caller
   // asked for no group and the changes landed as whatever steps AE recorded.
   var undoGroupName = (args.undoGroup === false) ? false : "AE MCP: run_jsx";
-  return __rjResult(eval(wrapper), undoGroupName);
+  // diff:true fingerprints the comp before and after, inside this one call —
+  // see snapshot.jsx. Null unless asked for, so the ordinary path is untouched.
+  var __d = __diffStart(args, null);
+  var __value;
+  try { __value = eval(wrapper); }
+  catch (__e) { __diffAnnotateError(__e, __d); throw __e; }
+  var __out = __rjResult(__value, undoGroupName);
+  if (__d) return __rjWithDiff(__out, __diffFinish(__d), undoGroupName);
+  return __out;
 });

--- a/packages/jsx/snapshot.jsx
+++ b/packages/jsx/snapshot.jsx
@@ -1,0 +1,597 @@
+// snapshot.jsx — a cheap structural fingerprint of a comp, and the diff
+// between two of them.
+//
+// Verifying a write today means reading the comp back and comparing by eye,
+// and every one of those reads is re-sent on every later request for the rest
+// of the session. A fingerprint is the other end of that trade: it records
+// what an agent actually checks after a write — which layers exist, what they
+// are called, where they sit in time, what they are parented to, how many
+// keyframes/expressions/effects they carry — and nothing else. The diff of two
+// of them is a few dozen tokens for "3 layers added: ids 512-514; layer 498
+// Opacity keys 0 -> 4" (issue #52).
+//
+// Cheapness is the whole point, so the walk stops at the layer's own Transform
+// group plus four named properties. It never opens an effect's parameters or a
+// shape layer's Contents — those are what make get_layer_full expensive, and a
+// fingerprint that costs as much as the read it replaces is worth nothing.
+//
+// That has a cost of its own, and per the "a scoped read must say what it left
+// out" rule it is stated rather than left to be discovered: a diff can only
+// report a field it records. __DIFF_COVERS travels with every diff for exactly
+// that reason — "no differences" must never be read as "identical".
+
+var __DIFF_COVERS = "Compares recorded fields only - not property values, expression text, " +
+  "effect parameters, masks or shape contents. \"No differences\" means none of the recorded fields moved, " +
+  "not that the two states render identically.";
+
+var __FP_COVERS = "A snapshot records, per layer: id, name, index, type, inPoint, outPoint, startTime, " +
+  "parentId, enabled, keyframe counts per Transform property (plus Marker, Time Remap and Source Text), " +
+  "expression count and effect count. Per comp: name, size, duration, frame rate, work area and markers. " +
+  "It does NOT record property values, expression text, effect parameters, mask shapes or shape contents, " +
+  "because reading those costs as much as the read this replaces.";
+
+// Times are floats out of AE and are compared, not displayed, so they are
+// rounded once here rather than at every comparison site.
+var __FP_PRECISION = 1000000;
+
+function __fpRound(n) {
+  if (typeof n !== "number") return n;
+  if (!isFinite(n)) return null;
+  return Math.round(n * __FP_PRECISION) / __FP_PRECISION;
+}
+
+// Properties worth a fingerprint that do not live under Transform. Each is one
+// guarded lookup; a layer that has none of them pays four null checks.
+var __FP_EXTRA_PROPS = ["Marker", "Time Remap", "Source Text", "Audio Levels"];
+
+function __fpCountProperty(p, out) {
+  if (!p) return;
+  var keys = 0;
+  try { keys = p.numKeys; } catch (e) { return; }
+  if (typeof keys !== "number") return;
+  if (keys > 0) out.keyCounts[p.name] = keys;
+  try {
+    if (p.canSetExpression && p.expression) out.expressionCount += 1;
+  } catch (e2) {}
+}
+
+function __fpLayer(l) {
+  var out = {
+    id: l.id,
+    name: l.name,
+    index: l.index,
+    type: __layerKind(l),
+    inPoint: __fpRound(l.inPoint),
+    outPoint: __fpRound(l.outPoint),
+    startTime: __fpRound(l.startTime),
+    parentId: null,
+    enabled: l.enabled,
+    keyCounts: {},
+    expressionCount: 0,
+    effectCount: 0
+  };
+  try { if (l.parent) out.parentId = l.parent.id; } catch (e0) {}
+
+  var tr = null;
+  try { tr = l.property("Transform"); } catch (e1) {}
+  if (tr) {
+    for (var i = 1; i <= tr.numProperties; i++) __fpCountProperty(tr.property(i), out);
+  }
+  for (var j = 0; j < __FP_EXTRA_PROPS.length; j++) {
+    var extra = null;
+    try { extra = l.property(__FP_EXTRA_PROPS[j]); } catch (e2) {}
+    __fpCountProperty(extra, out);
+  }
+  // Effects are counted, never walked. The parameter tree is the expensive
+  // part and an agent checking "did my effect land" only needs the count plus
+  // list_effects when it did not.
+  try {
+    var fx = l.property("Effects");
+    if (fx) out.effectCount = fx.numProperties;
+  } catch (e3) {}
+  return out;
+}
+
+function __fpCompMarkers(c) {
+  var out = [];
+  var mp = null;
+  try { mp = c.markerProperty; } catch (e) { return out; }
+  if (!mp) return out;
+  var n = 0;
+  try { n = mp.numKeys; } catch (e2) { return out; }
+  for (var i = 1; i <= n; i++) {
+    var mv = mp.keyValue(i);
+    out.push(String(__fpRound(mp.keyTime(i))) + "|" + String(mv.comment) + "|" + String(__fpRound(mv.duration)));
+  }
+  return out;
+}
+
+function __compFingerprint(compId) {
+  var c = getCompById(compId);
+  var fp = {
+    compId: c.id,
+    name: c.name,
+    width: c.width,
+    height: c.height,
+    duration: __fpRound(c.duration),
+    frameRate: __fpRound(c.frameRate),
+    workAreaStart: __fpRound(c.workAreaStart),
+    workAreaDuration: __fpRound(c.workAreaDuration),
+    numLayers: c.numLayers,
+    markers: __fpCompMarkers(c),
+    layers: []
+  };
+  for (var i = 1; i <= c.numLayers; i++) fp.layers.push(__fpLayer(c.layer(i)));
+  return fp;
+}
+
+// ---------------------------------------------------------------------------
+// The diff
+// ---------------------------------------------------------------------------
+// Pure: two fingerprints in, one object out, no AE. That is what lets it be
+// tested against synthetic input (tests/unit/comp-snapshot.mjs) — there is no
+// ExtendScript runtime on a runner and this is the part that has to be right.
+
+// Below a frame at any sane frame rate, above the float noise a round-trip
+// through JSON leaves behind. Without it a comp re-read after a frame-rate
+// change reports every layer "retimed" by 1e-15.
+var __DIFF_EPS = 0.000001;
+
+function __diffMoved(a, b) {
+  if (typeof a !== "number") return a !== b;
+  if (typeof b !== "number") return true;
+  return Math.abs(a - b) > __DIFF_EPS;
+}
+
+// ES3 has no Map. The "L" prefix keeps a numeric id away from anything already
+// on Object.prototype.
+function __fpById(fp) {
+  var m = {};
+  for (var i = 0; i < fp.layers.length; i++) m["L" + fp.layers[i].id] = fp.layers[i];
+  return m;
+}
+
+function __diffKeyCounts(a, b) {
+  var out = null;
+  var seen = {};
+  var k;
+  for (k in a) {
+    if (!a.hasOwnProperty(k)) continue;
+    seen[k] = true;
+    var bv = 0;
+    if (b.hasOwnProperty(k)) bv = b[k];
+    if (a[k] !== bv) {
+      if (!out) out = {};
+      out[k] = { from: a[k], to: bv };
+    }
+  }
+  for (k in b) {
+    if (!b.hasOwnProperty(k)) continue;
+    if (seen[k]) continue;
+    if (!out) out = {};
+    out[k] = { from: 0, to: b[k] };
+  }
+  return out;
+}
+
+var __DIFF_EXACT_FIELDS = ["name", "type", "enabled"];
+var __DIFF_TIME_FIELDS = ["inPoint", "outPoint", "startTime"];
+var __DIFF_COUNT_FIELDS = ["expressionCount", "effectCount"];
+
+// `index` is deliberately not compared here: inserting one layer shifts every
+// index below it, which would report twenty changed layers for one addition.
+// Relative order is compared separately, in __diffReordered.
+function __diffLayer(a, b) {
+  var ch = {};
+  var n = 0;
+  var i, k;
+  for (i = 0; i < __DIFF_EXACT_FIELDS.length; i++) {
+    k = __DIFF_EXACT_FIELDS[i];
+    if (a[k] !== b[k]) { ch[k] = { from: a[k], to: b[k] }; n += 1; }
+  }
+  for (i = 0; i < __DIFF_TIME_FIELDS.length; i++) {
+    k = __DIFF_TIME_FIELDS[i];
+    if (__diffMoved(a[k], b[k])) { ch[k] = { from: a[k], to: b[k] }; n += 1; }
+  }
+  for (i = 0; i < __DIFF_COUNT_FIELDS.length; i++) {
+    k = __DIFF_COUNT_FIELDS[i];
+    if (a[k] !== b[k]) { ch[k] = { from: a[k], to: b[k] }; n += 1; }
+  }
+  if (a.parentId !== b.parentId) { ch.parentId = { from: a.parentId, to: b.parentId }; n += 1; }
+  var kc = __diffKeyCounts(a.keyCounts || {}, b.keyCounts || {});
+  if (kc) { ch.keyCounts = kc; n += 1; }
+  if (n === 0) return null;
+  return { id: b.id, name: b.name, changes: ch };
+}
+
+// Only layers present on both sides, and only when their order relative to one
+// another actually changed. A layer added or removed elsewhere in the stack is
+// not a reorder of anything.
+function __diffReordered(before, after, aMap, bMap) {
+  var seqA = [];
+  var seqB = [];
+  var i;
+  for (i = 0; i < before.layers.length; i++) {
+    var idA = before.layers[i].id;
+    if (bMap.hasOwnProperty("L" + idA)) seqA.push(idA);
+  }
+  for (i = 0; i < after.layers.length; i++) {
+    var idB = after.layers[i].id;
+    if (aMap.hasOwnProperty("L" + idB)) seqB.push(idB);
+  }
+  if (seqA.length !== seqB.length) return null;
+  var same = true;
+  for (i = 0; i < seqA.length; i++) {
+    if (seqA[i] !== seqB[i]) { same = false; break; }
+  }
+  if (same) return null;
+  var posA = {};
+  for (i = 0; i < seqA.length; i++) posA["L" + seqA[i]] = i;
+  var moved = [];
+  for (i = 0; i < seqB.length; i++) {
+    var id = seqB[i];
+    if (posA["L" + id] === i) continue;
+    moved.push({
+      id: id,
+      name: bMap["L" + id].name,
+      fromIndex: aMap["L" + id].index,
+      toIndex: bMap["L" + id].index
+    });
+  }
+  if (moved.length === 0) return null;
+  return moved;
+}
+
+function __diffMarkers(a, b) {
+  if (a.length !== b.length) return { from: a.length, to: b.length };
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return { count: a.length, edited: true };
+  }
+  return null;
+}
+
+function __diffCompFields(a, b) {
+  var ch = {};
+  var n = 0;
+  if (a.name !== b.name) { ch.name = { from: a.name, to: b.name }; n += 1; }
+  if (a.width !== b.width || a.height !== b.height) {
+    ch.size = { from: [a.width, a.height], to: [b.width, b.height] };
+    n += 1;
+  }
+  if (__diffMoved(a.duration, b.duration)) { ch.duration = { from: a.duration, to: b.duration }; n += 1; }
+  if (__diffMoved(a.frameRate, b.frameRate)) { ch.frameRate = { from: a.frameRate, to: b.frameRate }; n += 1; }
+  if (__diffMoved(a.workAreaStart, b.workAreaStart) || __diffMoved(a.workAreaDuration, b.workAreaDuration)) {
+    ch.workArea = {
+      from: [a.workAreaStart, a.workAreaDuration],
+      to: [b.workAreaStart, b.workAreaDuration]
+    };
+    n += 1;
+  }
+  var mk = __diffMarkers(a.markers || [], b.markers || []);
+  if (mk) { ch.markers = mk; n += 1; }
+  if (n === 0) return null;
+  return ch;
+}
+
+// ---------- summary prose ----------
+
+function __diffPlural(n) {
+  if (n === 1) return "";
+  return "s";
+}
+
+// "512-514" for a run, "512, 517" otherwise. Ids come out of AE in creation
+// order, so a batch of new layers is nearly always consecutive and this is the
+// difference between a readable line and a wall of numbers.
+function __diffIdList(ids) {
+  if (!ids.length) return "";
+  var sorted = [];
+  for (var i = 0; i < ids.length; i++) sorted.push(ids[i]);
+  sorted.sort(function (x, y) { return x - y; });
+  var parts = [];
+  var start = sorted[0];
+  var prev = sorted[0];
+  for (var j = 1; j <= sorted.length; j++) {
+    var cur = sorted[j];
+    var breaks = true;
+    if (j < sorted.length && cur === prev + 1) breaks = false;
+    if (breaks) {
+      if (start === prev) parts.push(String(start));
+      else if (prev === start + 1) parts.push(String(start) + ", " + String(prev));
+      else parts.push(String(start) + "-" + String(prev));
+      start = cur;
+    }
+    prev = cur;
+  }
+  return parts.join(", ");
+}
+
+function __diffParentLabel(v) {
+  if (v === null || v === undefined) return "none";
+  return String(v);
+}
+
+function __diffLayerPhrases(entry) {
+  var label = "layer " + entry.id;
+  var c = entry.changes;
+  var out = [];
+  if (c.name) out.push(label + ' renamed "' + c.name.from + '" -> "' + c.name.to + '"');
+  if (c.enabled) {
+    if (c.enabled.to) out.push(label + " enabled");
+    else out.push(label + " disabled");
+  }
+  var times = [];
+  if (c.inPoint) times.push("in " + c.inPoint.from + " -> " + c.inPoint.to);
+  if (c.outPoint) times.push("out " + c.outPoint.from + " -> " + c.outPoint.to);
+  if (c.startTime) times.push("start " + c.startTime.from + " -> " + c.startTime.to);
+  if (times.length) out.push(label + " retimed (" + times.join(", ") + ")");
+  if (c.parentId) {
+    out.push(label + " re-parented " + __diffParentLabel(c.parentId.from) + " -> " + __diffParentLabel(c.parentId.to));
+  }
+  if (c.keyCounts) {
+    for (var k in c.keyCounts) {
+      if (!c.keyCounts.hasOwnProperty(k)) continue;
+      out.push(label + " " + k + " keys " + c.keyCounts[k].from + " -> " + c.keyCounts[k].to);
+    }
+  }
+  if (c.effectCount) out.push(label + " effects " + c.effectCount.from + " -> " + c.effectCount.to);
+  if (c.expressionCount) {
+    out.push(label + " expressions " + c.expressionCount.from + " -> " + c.expressionCount.to);
+  }
+  if (c.type) out.push(label + " type " + c.type.from + " -> " + c.type.to);
+  return out;
+}
+
+function __diffCompPhrases(ch) {
+  var out = [];
+  if (ch.name) out.push('comp renamed "' + ch.name.from + '" -> "' + ch.name.to + '"');
+  if (ch.size) {
+    out.push("comp resized " + ch.size.from[0] + "x" + ch.size.from[1] + " -> " + ch.size.to[0] + "x" + ch.size.to[1]);
+  }
+  if (ch.duration) out.push("comp duration " + ch.duration.from + " -> " + ch.duration.to);
+  if (ch.frameRate) out.push("comp frame rate " + ch.frameRate.from + " -> " + ch.frameRate.to);
+  if (ch.workArea) out.push("comp work area moved");
+  if (ch.markers) {
+    if (ch.markers.edited) out.push("comp markers edited");
+    else out.push("comp markers " + ch.markers.from + " -> " + ch.markers.to);
+  }
+  return out;
+}
+
+// One line. Past this many clauses the rest is counted rather than spelled out
+// — the structured fields carry everything, and a summary nobody reads to the
+// end is worse than a short one that names where to look.
+var __DIFF_SUMMARY_CLAUSES = 8;
+
+function __diffSummary(d) {
+  var parts = [];
+  var i;
+  if (d.added) {
+    var addedIds = [];
+    for (i = 0; i < d.added.length; i++) addedIds.push(d.added[i].id);
+    parts.push(d.added.length + " layer" + __diffPlural(d.added.length) + " added: ids " + __diffIdList(addedIds));
+  }
+  if (d.removed) {
+    var removedIds = [];
+    for (i = 0; i < d.removed.length; i++) removedIds.push(d.removed[i].id);
+    parts.push(d.removed.length + " layer" + __diffPlural(d.removed.length) + " removed: ids " + __diffIdList(removedIds));
+  }
+  if (d.reordered) {
+    parts.push(d.reordered.length + " layer" + __diffPlural(d.reordered.length) + " moved in the stack");
+  }
+  if (d.changed) {
+    for (i = 0; i < d.changed.length; i++) {
+      var phrases = __diffLayerPhrases(d.changed[i]);
+      for (var p = 0; p < phrases.length; p++) parts.push(phrases[p]);
+    }
+  }
+  if (d.comp) {
+    var compPhrases = __diffCompPhrases(d.comp);
+    for (i = 0; i < compPhrases.length; i++) parts.push(compPhrases[i]);
+  }
+  if (parts.length === 0) {
+    return "No differences in the recorded fields. Property values, expression text, effect parameters " +
+      "and shape contents are not compared, so this is not a claim that nothing changed at all.";
+  }
+  if (parts.length > __DIFF_SUMMARY_CLAUSES) {
+    var extra = parts.length - __DIFF_SUMMARY_CLAUSES;
+    parts = parts.slice(0, __DIFF_SUMMARY_CLAUSES);
+    parts.push("and " + extra + " more change" + __diffPlural(extra) + " (see the fields below)");
+  }
+  return parts.join("; ");
+}
+
+// Two fingerprints -> only what moved. Unchanged layers are counted, never
+// listed: listing them is the cost this whole thing exists to avoid.
+function __diffFingerprints(before, after) {
+  var aMap = __fpById(before);
+  var bMap = __fpById(after);
+  var added = [];
+  var removed = [];
+  var changed = [];
+  var unchanged = 0;
+  var i, l;
+  for (i = 0; i < after.layers.length; i++) {
+    l = after.layers[i];
+    var prev = aMap["L" + l.id];
+    if (!prev) {
+      added.push({ id: l.id, name: l.name, index: l.index, type: l.type });
+      continue;
+    }
+    var d = __diffLayer(prev, l);
+    if (d) changed.push(d);
+    else unchanged += 1;
+  }
+  for (i = 0; i < before.layers.length; i++) {
+    l = before.layers[i];
+    if (bMap.hasOwnProperty("L" + l.id)) continue;
+    removed.push({ id: l.id, name: l.name, index: l.index, type: l.type });
+  }
+  var reordered = __diffReordered(before, after, aMap, bMap);
+  var comp = __diffCompFields(before, after);
+
+  var out = { compId: after.compId, compName: after.name };
+  if (added.length) out.added = added;
+  if (removed.length) out.removed = removed;
+  if (changed.length) out.changed = changed;
+  if (reordered) out.reordered = reordered;
+  if (comp) out.comp = comp;
+  out.unchangedLayers = unchanged;
+  var count = added.length + removed.length + changed.length;
+  if (reordered) count += reordered.length;
+  if (comp) count += 1;
+  out.changeCount = count;
+  out.summary = __diffSummary(out);
+  out.covers = __DIFF_COVERS;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Ops
+// ---------------------------------------------------------------------------
+// Both are internal: the tools an agent sees are snapshot_comp and diff_comp,
+// and those are half server-resident. Only the panel can read After Effects,
+// and only the server can remember anything between calls — so the server
+// keeps the fingerprint and these two gather it. See snapshots/store.ts.
+
+OPS._comp_fingerprint = noUndo(function (args) {
+  return __compFingerprint(args.compId);
+});
+
+OPS._comp_diff = noUndo(function (args) {
+  var before = args.since;
+  if (!before || !before.layers) {
+    throw new Error("_comp_diff needs a stored fingerprint in `since` (the MCP server supplies it from the snapshot id)");
+  }
+  var compId = args.compId;
+  if (compId === undefined || compId === null) compId = before.compId;
+  var after = __compFingerprint(compId);
+  return { diff: __diffFingerprints(before, after), fingerprint: after };
+});
+
+// ---------------------------------------------------------------------------
+// diff:true on the write ops
+// ---------------------------------------------------------------------------
+// The before-fingerprint has to be taken inside the same bridge call as the
+// write, or it is not a before at all: a separate snapshot_comp is a second
+// round-trip during which anything can happen, and the agent has to remember to
+// make it. run_jsx and run_batch therefore fingerprint, run, fingerprint again,
+// and diff — one call, one answer.
+
+function __diffPushUnique(list, v) {
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] === v) return;
+  }
+  list.push(v);
+}
+
+// Explicit diffCompId wins. Otherwise a batch names its own comps in its ops,
+// and a script gets the comp the user is looking at. When none of the three
+// yields anything the diff is refused with a reason rather than quietly
+// skipped — a missing diff that looks like "nothing changed" is the failure
+// this whole feature exists to prevent.
+function __diffCompIds(args, ops) {
+  var ids = [];
+  if (args && args.diffCompId !== undefined && args.diffCompId !== null) {
+    __diffPushUnique(ids, args.diffCompId);
+    return ids;
+  }
+  if (ops) {
+    for (var i = 0; i < ops.length; i++) {
+      var a = ops[i].args;
+      if (a && typeof a.compId === "number") __diffPushUnique(ids, a.compId);
+    }
+    if (ids.length > 0) return ids;
+  }
+  var active = null;
+  try { active = app.project.activeItem; } catch (e) {}
+  if (active && active instanceof CompItem) __diffPushUnique(ids, active.id);
+  return ids;
+}
+
+function __diffStart(args, ops) {
+  if (!args || !args.diff) return null;
+  var ids = __diffCompIds(args, ops);
+  if (ids.length === 0) {
+    return {
+      unavailable: true,
+      reason: "no compId appeared in this call and no composition is open in the viewer — pass diffCompId to name the comp to fingerprint"
+    };
+  }
+  var state = { ids: ids, before: [], unavailable: false };
+  for (var i = 0; i < ids.length; i++) {
+    try {
+      state.before.push(__compFingerprint(ids[i]));
+    } catch (e) {
+      return { unavailable: true, reason: "comp " + ids[i] + " could not be fingerprinted before the call: " + e.message };
+    }
+  }
+  return state;
+}
+
+function __diffFinish(state) {
+  if (!state) return null;
+  if (state.unavailable) {
+    return {
+      unavailable: true,
+      reason: state.reason,
+      summary: "No diff was taken: " + state.reason + ". The call itself is unaffected."
+    };
+  }
+  var comps = [];
+  var total = 0;
+  for (var i = 0; i < state.before.length; i++) {
+    var b = state.before[i];
+    var after = null;
+    try {
+      after = __compFingerprint(b.compId);
+    } catch (e) {
+      comps.push({
+        compId: b.compId,
+        compName: b.name,
+        gone: true,
+        changeCount: 1,
+        summary: "comp " + b.compId + ' ("' + b.name + '") can no longer be read: ' + e.message
+      });
+      total += 1;
+      continue;
+    }
+    var d = __diffFingerprints(b, after);
+    comps.push(d);
+    total += d.changeCount;
+  }
+  if (comps.length === 1) return comps[0];
+  var parts = [];
+  for (var j = 0; j < comps.length; j++) parts.push("comp " + comps[j].compId + ": " + comps[j].summary);
+  return { comps: comps, changeCount: total, summary: parts.join(" | "), covers: __DIFF_COVERS };
+}
+
+// A script or batch that threw still changed whatever it changed before it
+// stopped, and nothing rolls back. Finding that stop point by reading the comp
+// back is one of the three cases issue #52 was opened for, so the diff is put
+// where the agent will actually see it: on the error. The error object itself
+// is mutated rather than replaced, so `line` and `stack` survive for the
+// caller's own reporting.
+function __diffAnnotateError(e, state) {
+  if (!state) return;
+  var d = null;
+  try { d = __diffFinish(state); } catch (e2) { return; }
+  if (!d || !d.summary) return;
+  try {
+    e.message = String(e.message) + " || Changed before it stopped: " + d.summary +
+      " (nothing rolls back - read the state back rather than re-running)";
+  } catch (e3) {}
+}
+
+// run_jsx returns whatever the script returned, which may be a number or a
+// string with nowhere to hang a diff on. With diff:true it is enveloped
+// instead. The null envelope __rjResult already builds is the right shape
+// already, so that one is extended rather than nested inside a second one.
+function __rjWithDiff(out, diff, undoGroupName) {
+  if (out && typeof out === "object" && !(out instanceof Array) &&
+      out.ok === true && out.returned === null && out.note) {
+    out.diff = diff;
+    return out;
+  }
+  return { ok: true, returned: out, undoGroup: undoGroupName, diff: diff };
+}

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -12,6 +12,8 @@ import { schemas } from "@engineroom/shared";
 import { HttpClient } from "./bridge/httpClient.js";
 import { WsClient } from "./bridge/wsClient.js";
 import { JobManager } from "./jobs/manager.js";
+import { SnapshotStore } from "./snapshots/store.js";
+import type { CompFingerprint } from "./snapshots/store.js";
 import { descriptions } from "./tools/descriptions.js";
 import { AeError, BridgeTimeoutError, BridgeUnreachableError } from "./util/errors.js";
 import { checkSetup } from "./setup/check.js";
@@ -48,6 +50,11 @@ const SERVER_OPS = new Set([
   "list_known_issues",
   "mark_issue_reported",
 ]);
+// Half server-resident: only the panel can read After Effects, only the server
+// can remember anything between calls. These forward an internal read op to
+// gather a fingerprint and keep the result in `SnapshotStore` — they are not in
+// SERVER_OPS, because unlike those they do touch the bridge.
+const SNAPSHOT_OPS = new Set(["snapshot_comp", "diff_comp"]);
 
 /**
  * `ae_guide` exists because the two better carriers are not universal. The
@@ -78,6 +85,7 @@ export function createServer() {
 
   const bridge = new HttpClient();
   const jobs = new JobManager();
+  const snapshots = new SnapshotStore();
   const ws = new WsClient(bridge.port, jobs);
   ws.start();
   const panelGate = createPanelGate(bridge);
@@ -263,6 +271,10 @@ export function createServer() {
 
     // Forward to panel.
     try {
+      // Inside this try so the panel's own error mapping — timeouts, AeError,
+      // the Unknown-op backstop — applies to the internal ops these forward.
+      if (SNAPSHOT_OPS.has(name)) return await runSnapshotOp(name, args, bridge, snapshots);
+
       const result = await bridge.runOp(name, args, progressToken);
 
       // Async envelope handling for run_batch
@@ -343,6 +355,75 @@ export function createServer() {
 
   return server;
 }
+
+/**
+ * `snapshot_comp` and `diff_comp`.
+ *
+ * The split is the point: the panel gathers a fingerprint because only it can
+ * read After Effects, and the server keeps it because a snapshot must not be
+ * written into the user's project (see snapshots/store.ts). Neither tool sends
+ * the fingerprint back unless asked — returning it by default would reintroduce
+ * exactly the context cost the snapshot exists to avoid, since a tool result is
+ * re-sent on every later request for the rest of the session.
+ */
+async function runSnapshotOp(
+  name: string,
+  args: unknown,
+  bridge: HttpClient,
+  snapshots: SnapshotStore
+) {
+  if (name === "snapshot_comp") {
+    const a = args as { compId: number; includeFingerprint?: boolean };
+    const fingerprint = (await bridge.runOp("_comp_fingerprint", { compId: a.compId })) as CompFingerprint;
+    const snap = snapshots.store(fingerprint);
+    return textResult({
+      snapshotId: snap.id,
+      compId: snap.compId,
+      compName: snap.compName,
+      layers: snap.layerCount,
+      takenAt: new Date(snap.takenAt).toISOString(),
+      next: `Do the work, then diff_comp({ since: "${snap.id}" }).`,
+      lifetime:
+        "Held in this MCP server's memory for the length of the session, not written into the After Effects project.",
+      covers: SNAPSHOT_COVERS,
+      fingerprint: a.includeFingerprint ? fingerprint : undefined,
+    });
+  }
+
+  const d = args as { since: string; compId?: number; includeFingerprint?: boolean };
+  const previous = snapshots.get(d.since);
+  if (!previous) return errorResult(snapshots.missingMessage(d.since));
+  if (d.compId !== undefined && d.compId !== previous.compId) {
+    return errorResult(
+      `Snapshot ${d.since} is of comp ${previous.compId} ("${previous.compName}"), not comp ${d.compId}. ` +
+        `A diff only means anything against a snapshot of the same comp — omit compId, or snapshot_comp(${d.compId}) first.`
+    );
+  }
+  const res = (await bridge.runOp("_comp_diff", {
+    compId: previous.compId,
+    since: previous.fingerprint,
+  })) as { diff: Record<string, unknown>; fingerprint: CompFingerprint };
+  // The fresh fingerprint becomes a snapshot of its own, so a verify-as-you-go
+  // loop can keep diffing forward without a second call per step.
+  const next = snapshots.store(res.fingerprint);
+  return textResult({
+    ...res.diff,
+    since: d.since,
+    snapshotId: next.id,
+    fingerprint: d.includeFingerprint ? res.fingerprint : undefined,
+  });
+}
+
+/**
+ * What a snapshot is and is not, quoted back on every one taken. A diff can
+ * only report a field it records, so "no differences" has to be readable as
+ * "none of these moved" and never as "identical" — the same rule that makes
+ * every other scoped read here name what it left out.
+ */
+const SNAPSHOT_COVERS =
+  "Records layer id/name/index/type, in/out/start, parent, enabled, keyframe counts, expression count and " +
+  "effect count, plus comp size/duration/frame rate/work area/markers. Property values, expression text, " +
+  "effect parameters and shape contents are not recorded.";
 
 /**
  * Caches the panel-version verdict so it costs one /health per session rather

--- a/packages/mcp-server/src/snapshots/store.ts
+++ b/packages/mcp-server/src/snapshots/store.ts
@@ -1,0 +1,97 @@
+/**
+ * The comp fingerprints `snapshot_comp` takes, held in this server's memory.
+ *
+ * They are deliberately not written into the After Effects project. A snapshot
+ * is scaffolding for one session's verification — it answers "what did my last
+ * write actually do" — and putting it in the .aep would mean a tool that
+ * *reads* the project modifies it, showing up in the user's undo stack and in
+ * their file, for a value nobody wants to keep. The panel gathers the
+ * fingerprint because only the panel can talk to AE; the server keeps it
+ * because only the server has anywhere to keep it that costs the project
+ * nothing.
+ *
+ * The consequence is that snapshots live exactly as long as the server process,
+ * which for a stdio MCP client is the session. That is acceptable — nothing
+ * needs a snapshot from yesterday — but it must never be discovered as a
+ * cryptic failure, so `missingMessage` says it in full and names the way
+ * forward.
+ */
+
+export interface CompFingerprint {
+  compId: number;
+  name: string;
+  numLayers: number;
+  layers: unknown[];
+  [key: string]: unknown;
+}
+
+export interface StoredSnapshot {
+  id: string;
+  compId: number;
+  compName: string;
+  layerCount: number;
+  takenAt: number;
+  fingerprint: CompFingerprint;
+}
+
+/** Enough for any realistic verify-as-you-go session; small enough to be free. */
+const DEFAULT_MAX = 32;
+
+export class SnapshotStore {
+  private snapshots = new Map<string, StoredSnapshot>();
+  private seq = 0;
+
+  constructor(private readonly max: number = DEFAULT_MAX) {}
+
+  store(fingerprint: CompFingerprint): StoredSnapshot {
+    this.seq += 1;
+    const snapshot: StoredSnapshot = {
+      id: `snap_${this.seq}`,
+      compId: fingerprint.compId,
+      compName: fingerprint.name,
+      layerCount: Array.isArray(fingerprint.layers) ? fingerprint.layers.length : 0,
+      takenAt: Date.now(),
+      fingerprint,
+    };
+    this.snapshots.set(snapshot.id, snapshot);
+    // Map iterates in insertion order, so the first key is the oldest.
+    while (this.snapshots.size > this.max) {
+      const oldest = this.snapshots.keys().next();
+      if (oldest.done) break;
+      this.snapshots.delete(oldest.value);
+    }
+    return snapshot;
+  }
+
+  get(id: string): StoredSnapshot | undefined {
+    return this.snapshots.get(id);
+  }
+
+  size(): number {
+    return this.snapshots.size;
+  }
+
+  ids(): string[] {
+    return [...this.snapshots.keys()];
+  }
+
+  /**
+   * Why an id is not here, and what to do instead. An agent hitting this has
+   * already done the work it wanted to verify, so "unknown snapshot" on its own
+   * would strand it.
+   */
+  missingMessage(id: string): string {
+    const held = this.ids();
+    const listing =
+      held.length === 0
+        ? "No snapshots are held in this session yet."
+        : `Held right now: ${held.join(", ")}.`;
+    return (
+      `No snapshot "${id}". Snapshots live in this server's memory for the length of the session: ` +
+      `they are gone when the MCP server restarts, and the oldest is dropped once ${this.max} are held. ` +
+      `${listing} Take a fresh one with snapshot_comp, do the work, then diff against that id. ` +
+      `To verify a write you have already made, read the comp back with list_layers instead — ` +
+      `a diff can only compare against a snapshot taken beforehand.`
+    );
+  }
+}

--- a/packages/mcp-server/src/tools/descriptions.ts
+++ b/packages/mcp-server/src/tools/descriptions.ts
@@ -12,6 +12,12 @@ export const descriptions: Record<string, string> = {
   set_comp: "Modify a comp (name, dims, fps, duration, work area, bg). Undefined fields unchanged.",
   delete_comp: "Delete a comp. Reversible only via AE's Undo.",
   set_active_comp: "Focus a comp in the viewer/timeline.",
+  duplicate_comp:
+    "Copy a comp. Returns the new comp id, so you never have to find it by name. Use this instead of run_jsx + CompItem.duplicate(). By default the copy is SHALLOW, exactly like AE's own Duplicate: its precomp layers point at the same nested comps as the original, so editing one of those edits both. `deep:true` duplicates the nested comps too and re-points the copy at them — that is what 'a variant of this rig' means. A nested comp used by several layers is duplicated once and reused. `folderId` files the copy in a project folder; `nameSuffix` names the nested copies '<original><suffix>'.",
+  snapshot_comp:
+    "Take a cheap structural fingerprint of a comp and keep it in this server's memory. Returns a snapshotId and nothing else worth tokens — call it BEFORE a write, then diff_comp afterwards to learn what the write actually did, instead of reading the comp back and comparing by eye. It records per layer: id, name, index, type, in/out/start, parent, enabled, keyframe counts, expression count, effect count; per comp: size, duration, frame rate, work area, markers. It does NOT record property values, expression text, effect parameters, masks or shape contents. Nothing is written into the AE project, and snapshots are gone when the session ends.",
+  diff_comp:
+    "What changed in a comp since a snapshot: layers added, removed, renamed, retimed, re-parented, keyframe counts that moved, expressions and effects gained or lost — and nothing at all for unchanged layers, which are only counted. A few dozen tokens where list_layers + get_layer_full is thousands, and it answers the three questions worth asking after a write: which layer is the new one, where did a failed script stop, and did the assembly land. Only the recorded fields are compared, so 'no differences' means none of THOSE moved, not that the comp is identical. Returns a fresh snapshotId so you can keep diffing forward.",
 
   // ---------- layers ----------
   list_layers: "Layers in a comp, one-line each. Use get_layer_full for details. Pass `include` to trim it — `include: []` returns just id/index/name/type, the cheapest way to learn what is in a comp.",
@@ -80,7 +86,7 @@ export const descriptions: Record<string, string> = {
   screenshot_layer: "ONE-OFF visual check of a single layer (solo'd) at a time. Same one-off rule and same downsample guidance as screenshot_frame. The same 'Stale frame' and `empty:true` non-image results apply.",
 
   // ---------- batch ----------
-  run_batch: "Many ops in one ExtendScript pass, one undo step. >500 ops returns a jobId + streams progress; use await_job. transactional:true (default) rolls back on first error.",
+  run_batch: "Many ops in one ExtendScript pass, one undo step. >500 ops returns a jobId + streams progress; use await_job. transactional:true (default) rolls back on first error. `diff:true` appends a structural diff of the comps the batch touched — what it added, retimed, re-parented and keyframed — and on a failure that diff rides on the error, which is the cheapest way to find where a half-applied batch stopped.",
 
   // ---------- explore ----------
   get_project_summary: "Project state: path, item count, active item, flat item list with type (comp | footage | solid | folder | unknown — same vocabulary as a layer's sourceType).",
@@ -90,7 +96,8 @@ export const descriptions: Record<string, string> = {
   run_jsx:
     "Escape hatch: arbitrary ExtendScript in an undo group. `comp`/`app`/`OPS`/helpers in scope. `return X` sends a value back — arrays and nested objects come back whole. Anything that cannot be JSON is replaced in place by a marker string, never dropped: `\"[function]\"`, `\"[undefined]\"`, `\"[circular]\"`, `\"[max depth]\"`, `\"[NaN]\"`, and live AE objects as `\"[CompItem \\\"Main\\\" #12]\"` — a handle to pass to a real read tool, not a walk of the object. An empty result therefore means the script really returned nothing. " +
     "A script with no explicit `return` — including one ending in a bare expression, which does NOT return its value — comes back as `{ok:true, returned:null, undoGroup, note}`. That means it ran to completion; it did **not** fail, so do not re-run it. Nothing rolls back, so re-running a mutating script applies it twice. " +
-    "AE refuses copyToComp for a layer with a parent or a linked expression while an undo group is open: call `withoutUndoGroup(function(){ … })` around just that part, or pass undoGroup:false for the whole script (its changes then land as whatever undo steps AE records on its own, not one). Keep loops short — ExtendScript is single-threaded and freezes the user's UI.",
+    "AE refuses copyToComp for a layer with a parent or a linked expression while an undo group is open: call `withoutUndoGroup(function(){ … })` around just that part, or pass undoGroup:false for the whole script (its changes then land as whatever undo steps AE records on its own, not one). Keep loops short — ExtendScript is single-threaded and freezes the user's UI. " +
+    "`diff:true` fingerprints the comp before and after the script and appends only what changed, so the script reports what it actually did instead of you reading the comp back; with it the answer is always `{ok, returned, diff}`. If the script throws, that diff is appended to the error — which is how you find where a half-applied script stopped, since nothing rolls back.",
 
   // ---------- footage ----------
   import_footage:

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -67,6 +67,39 @@ export const SetComp = z.object({
 });
 export const DeleteComp = z.object({ compId: z.number() });
 export const SetActiveComp = z.object({ compId: z.number() });
+export const DuplicateComp = z
+  .object({
+    compId: z.number(),
+    name: z.string().optional().describe("Name for the copy. Omit to take AE's own ('<name> 2')."),
+    folderId: z.number().optional()
+      .describe("Project folder to put the copy in. Must be a folder item id from get_project_summary."),
+    deep: z.boolean().default(false).optional()
+      .describe(
+        "Also duplicate the nested precomps and re-point the copy's layers at them. Off by default, which matches AE's own Duplicate: a shallow copy shares its nested comps with the original, so editing one edits both."
+      ),
+    nameSuffix: z.string().optional()
+      .describe("With deep:true, name each duplicated nested comp '<original><nameSuffix>'. Omit to let AE name them."),
+  })
+  .strict();
+
+// ---------- comp snapshots (half server-resident: the panel gathers, the server remembers) ----------
+export const SnapshotComp = z
+  .object({
+    compId: z.number(),
+    includeFingerprint: z.boolean().default(false).optional()
+      .describe(
+        "Return the fingerprint itself as well as its id. Off by default — returning it reintroduces exactly the context cost a snapshot exists to avoid."
+      ),
+  })
+  .strict();
+export const DiffComp = z
+  .object({
+    since: z.string().describe("A snapshotId from an earlier snapshot_comp or diff_comp."),
+    compId: z.number().optional().describe("Defaults to the comp the snapshot was taken of; pass it only to assert which comp you mean."),
+    includeFingerprint: z.boolean().default(false).optional()
+      .describe("Return the new fingerprint as well as the diff. Off by default."),
+  })
+  .strict();
 
 // ---------- layers ----------
 export const ListLayers = z.object({
@@ -489,11 +522,31 @@ export const ScreenshotLayer = z.object({
   downsample: downsampleParam,
 });
 
+/**
+ * The write ops' opt-in structural diff. The before-fingerprint has to be taken
+ * inside the same bridge call as the write — a separate snapshot_comp is a
+ * second round-trip during which anything can happen — so these two are read by
+ * the panel, not the server.
+ */
+const diffParam = z
+  .boolean()
+  .default(false)
+  .optional()
+  .describe(
+    "Fingerprint the comp before and after this call and append only what changed (layers added/removed/renamed/retimed/re-parented, keyframe counts, expression and effect counts). A few dozen tokens instead of reading the comp back. If the call fails, the diff of what landed before it stopped is appended to the error."
+  );
+const diffCompIdParam = z
+  .number()
+  .optional()
+  .describe("Which comp `diff` should fingerprint. Defaults to the comps this call names, else the comp open in the viewer.");
+
 // ---------- batch ----------
 export const RunBatch = z.object({
   ops: z.array(z.object({ op: z.string(), args: z.unknown() })),
   transactional: z.boolean().default(true).optional(),
   undoGroupName: z.string().default("AE MCP Batch").optional(),
+  diff: diffParam,
+  diffCompId: diffCompIdParam,
 });
 
 // ---------- explore ----------
@@ -510,6 +563,8 @@ export const RunJsx = z.object({
   code: z.string(),
   undoGroup: z.boolean().default(true).optional()
     .describe("Wrap the script in one undo step. Set false only for the operations AE refuses while an undo group is open — copyToComp on a layer with a parent or a linked expression. The script's changes then land as whatever undo steps AE records on its own."),
+  diff: diffParam,
+  diffCompId: diffCompIdParam,
 });
 
 // ---------- footage ----------
@@ -659,6 +714,9 @@ export const OpSchemas = {
   set_comp: SetComp,
   delete_comp: DeleteComp,
   set_active_comp: SetActiveComp,
+  duplicate_comp: DuplicateComp,
+  snapshot_comp: SnapshotComp,
+  diff_comp: DiffComp,
   // layers
   list_layers: ListLayers,
   get_layer_full: GetLayerFull,

--- a/scripts/bundle-jsx.mjs
+++ b/scripts/bundle-jsx.mjs
@@ -17,6 +17,7 @@ const order = [
   "ids.jsx",
   "comps.jsx",
   "layers.jsx",
+  "snapshot.jsx",
   "transforms.jsx",
   "keyframes.jsx",
   "expressions.jsx",

--- a/tests/unit/comp-snapshot.mjs
+++ b/tests/unit/comp-snapshot.mjs
@@ -1,0 +1,563 @@
+// The comp fingerprint and the diff of two of them, out of packages/jsx/snapshot.jsx.
+//
+// Verifying a write by reading the comp back costs thousands of tokens, and a
+// tool result is re-sent on every later request for the rest of the session
+// (issue #52). A fingerprint plus a diff is a few dozen tokens for the same
+// answer — but only if three things hold, and all three are easy to get wrong:
+//
+//   - It stays CHEAP. The walk must never open an effect's parameters or a
+//     shape layer's Contents; those are what make get_layer_full expensive, and
+//     a fingerprint costing as much as the read it replaces is worth nothing.
+//     Probes on the stub count every such access and the test fails on one.
+//   - It reports ONLY what changed. Unchanged layers are counted, never listed,
+//     and inserting a layer must not report every layer below it as moved just
+//     because its index shifted.
+//   - It says what it does NOT cover. A diff can only report a field it
+//     records, so "no differences" has to be readable as "none of these moved"
+//     and never as "identical".
+//
+// There is no ExtendScript runtime on a runner, so After Effects is stubbed:
+// the fingerprint walk needs numProperties/property()/numKeys and nothing else,
+// and the diff is pure — two objects in, one out.
+//
+//   node tests/unit/comp-snapshot.mjs
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (f) => fs.readFileSync(path.join(root, "packages", "jsx", f), "utf8");
+
+const ctx = { OPS: {}, noUndo: (fn) => fn, noUndoWhen: (p, fn) => fn, undoNamed: (n, fn) => fn };
+vm.createContext(ctx);
+
+// A fake After Effects, built inside the VM realm because the sources lean on
+// `instanceof` and that compares against this realm's constructors.
+vm.runInContext(
+  `
+  function CompItem() {}
+  function FolderItem() {}
+  function FootageItem() {}
+  function AVLayer() {}
+  function TextLayer() {}
+  function ShapeLayer() {}
+  function CameraLayer() {}
+  function LightLayer() {}
+
+  // Every read the fingerprint is forbidden to make lands here.
+  var PROBE = { effectParams: 0, shapeContents: 0 };
+
+  function leaf(name, opts) {
+    var p = { name: name, numKeys: 0, canSetExpression: true, expression: "" };
+    if (opts) { for (var k in opts) p[k] = opts[k]; }
+    return p;
+  }
+
+  function group(kids, onRead) {
+    return {
+      numProperties: kids.length,
+      property: function (i) { if (onRead) onRead(); return kids[i - 1]; }
+    };
+  }
+
+  // The five 2D transform properties AE gives every layer.
+  function transformGroup(overrides) {
+    var names = ["Anchor Point", "Position", "Scale", "Rotation", "Opacity"];
+    var kids = [];
+    for (var i = 0; i < names.length; i++) {
+      var o = null;
+      if (overrides && overrides[names[i]]) o = overrides[names[i]];
+      kids.push(leaf(names[i], o));
+    }
+    return group(kids, null);
+  }
+
+  // Effects, whose parameters must never be walked: reading one trips PROBE.
+  function effectsGroup(count) {
+    var kids = [];
+    for (var i = 0; i < count; i++) kids.push(leaf("Effect " + (i + 1)));
+    return group(kids, function () { PROBE.effectParams += 1; });
+  }
+
+  function shapeContents() {
+    return group([leaf("Group 1")], function () { PROBE.shapeContents += 1; });
+  }
+
+  // spec: {id, name, index, in, out, start, parent, enabled, transform,
+  //        effects, keys:{Marker:n,...}, exprs:{...}}
+  function mkLayer(kind, spec) {
+    var ctors = { text: TextLayer, shape: ShapeLayer, camera: CameraLayer, light: LightLayer, av: AVLayer };
+    var Ctor = ctors[kind] || AVLayer;
+    var l = new Ctor();
+    l.id = spec.id;
+    l.name = spec.name;
+    l.index = spec.index;
+    l.inPoint = spec["in"] === undefined ? 0 : spec["in"];
+    l.outPoint = spec.out === undefined ? 5 : spec.out;
+    l.startTime = spec.start === undefined ? 0 : spec.start;
+    l.enabled = spec.enabled === undefined ? true : spec.enabled;
+    l.parent = spec.parent || null;
+    l.nullLayer = false;
+    l.adjustmentLayer = false;
+    l.source = spec.source || null;
+
+    var tr = transformGroup(spec.transform || null);
+    var extras = spec.extras || {};
+    var fx = effectsGroup(spec.effects === undefined ? 0 : spec.effects);
+    var contents = shapeContents();
+    l.property = function (n) {
+      if (n === "Transform") return tr;
+      if (n === "Effects") return fx;
+      if (n === "Contents") return contents;
+      if (extras.hasOwnProperty(n)) return extras[n];
+      return null;
+    };
+    return l;
+  }
+
+  function mkComp(spec) {
+    var c = new CompItem();
+    c.id = spec.id;
+    c.name = spec.name;
+    c.width = spec.width === undefined ? 1920 : spec.width;
+    c.height = spec.height === undefined ? 1080 : spec.height;
+    c.duration = spec.duration === undefined ? 10 : spec.duration;
+    c.frameRate = spec.frameRate === undefined ? 30 : spec.frameRate;
+    c.workAreaStart = spec.workAreaStart === undefined ? 0 : spec.workAreaStart;
+    c.workAreaDuration = spec.workAreaDuration === undefined ? 10 : spec.workAreaDuration;
+    var layers = spec.layers || [];
+    c.numLayers = layers.length;
+    c.layer = function (i) { return layers[i - 1]; };
+    c.markerProperty = spec.markers || { numKeys: 0, keyTime: function () { return 0; }, keyValue: function () { return {}; } };
+    return c;
+  }
+
+  var PROJECT = { items: [] };
+  var app = {
+    project: {
+      activeItem: null,
+      itemByID: function (id) {
+        for (var i = 0; i < PROJECT.items.length; i++) {
+          if (PROJECT.items[i].id === id) return PROJECT.items[i];
+        }
+        return null;
+      }
+    }
+  };
+  function setProject(items, active) {
+    PROJECT.items = items;
+    app.project.activeItem = active || null;
+  }
+  `,
+  ctx,
+);
+
+vm.runInContext(read("ids.jsx"), ctx, { filename: "ids.jsx" });
+vm.runInContext(read("layers.jsx"), ctx, { filename: "layers.jsx" });
+vm.runInContext(read("snapshot.jsx"), ctx, { filename: "snapshot.jsx" });
+
+let passed = 0;
+const ok = (cond, msg) => { assert.ok(cond, msg); passed++; };
+const eq = (a, b, msg) => { assert.deepEqual(a, b, msg); passed++; };
+
+const call = (name) => vm.runInContext(name, ctx);
+const plain = (v) => JSON.parse(JSON.stringify(v));
+// Rebuilds a host-realm object inside the VM, so the code under test only ever
+// sees objects from its own realm.
+const intoVm = (v) => vm.runInContext("JSON.parse", ctx)(JSON.stringify(v));
+const diff = (a, b) => plain(call("__diffFingerprints")(intoVm(a), intoVm(b)));
+
+// ---------------------------------------------------------------------------
+// The fingerprint
+// ---------------------------------------------------------------------------
+{
+  vm.runInContext(
+    `
+    var parentLayer = mkLayer("av", { id: 10, name: "Null", index: 3 });
+    var comp = mkComp({
+      id: 1, name: "Main", duration: 12, layers: [
+        mkLayer("text", {
+          id: 11, name: "Title", index: 1, in: 1, out: 4, start: 0.5,
+          parent: parentLayer, effects: 2,
+          transform: {
+            Position: { numKeys: 4 },
+            Opacity: { expression: "wiggle(1,10)" }
+          },
+          extras: {
+            Marker: { name: "Marker", numKeys: 2 },
+            "Source Text": { name: "Source Text", numKeys: 3, canSetExpression: true, expression: "" }
+          }
+        }),
+        mkLayer("shape", { id: 12, name: "Box", index: 2 }),
+        parentLayer
+      ]
+    });
+    setProject([comp], comp);
+    `,
+    ctx,
+  );
+
+  const fp = plain(call("__compFingerprint")(1));
+
+  eq(fp.compId, 1, "the comp id travels with the fingerprint");
+  eq(fp.name, "Main");
+  eq(fp.duration, 12);
+  eq(fp.layers.length, 3, "one entry per layer");
+
+  const title = fp.layers[0];
+  eq(title.id, 11);
+  eq(title.name, "Title");
+  eq(title.index, 1);
+  eq(title.type, "text", "the real __layerKind decides the type, not the fingerprint");
+  eq([title.inPoint, title.outPoint, title.startTime], [1, 4, 0.5], "timing is recorded");
+  eq(title.parentId, 10, "parenting is recorded by id, never by index");
+  eq(title.enabled, true);
+  eq(title.effectCount, 2, "effects are counted");
+  eq(title.expressionCount, 1, "an expression on a Transform property is counted");
+  eq(
+    title.keyCounts,
+    { Position: 4, Marker: 2, "Source Text": 3 },
+    "only properties that actually carry keyframes are listed",
+  );
+  eq(fp.layers[1].keyCounts, {}, "a layer with no animation carries no key counts at all");
+  eq(fp.layers[2].parentId, null, "an unparented layer records null, not a missing key");
+
+  // The reason this is a fingerprint and not a read.
+  eq(call("PROBE").effectParams, 0, "an effect's parameters must never be walked");
+  eq(call("PROBE").shapeContents, 0, "a shape layer's Contents must never be walked");
+  ok(JSON.stringify(fp).length < 1200, `a three-layer fingerprint should be small: ${JSON.stringify(fp).length} bytes`);
+}
+
+// ---------------------------------------------------------------------------
+// The diff
+// ---------------------------------------------------------------------------
+
+// A minimal synthetic fingerprint, so each case below changes exactly one thing.
+const layer = (over = {}) => ({
+  id: 100, name: "L", index: 1, type: "shape",
+  inPoint: 0, outPoint: 5, startTime: 0, parentId: null, enabled: true,
+  keyCounts: {}, expressionCount: 0, effectCount: 0,
+  ...over,
+});
+const comp = (layers, over = {}) => ({
+  compId: 7, name: "Main", width: 1920, height: 1080,
+  duration: 10, frameRate: 30, workAreaStart: 0, workAreaDuration: 10,
+  numLayers: layers.length, markers: [], layers,
+  ...over,
+});
+
+// ---------- nothing changed ----------
+{
+  const base = comp([layer({ id: 100 }), layer({ id: 101, index: 2 })]);
+  const d = diff(base, base);
+  eq(d.changeCount, 0, "an unchanged comp has no changes");
+  eq(d.added, undefined, "empty buckets are omitted, not sent as []");
+  eq(d.removed, undefined);
+  eq(d.changed, undefined);
+  eq(d.reordered, undefined);
+  eq(d.unchangedLayers, 2, "unchanged layers are counted, never listed");
+  ok(/No differences in the recorded fields/.test(d.summary), "the summary has to say so in words");
+  ok(/not compared/.test(d.summary), '"no differences" must never read as "identical"');
+  ok(/not property values/.test(d.covers), "every diff carries what it does not cover");
+}
+
+// ---------- layers added ----------
+{
+  const before = comp([layer({ id: 498 })]);
+  const after = comp([
+    layer({ id: 498 }),
+    layer({ id: 512, name: "a", index: 2 }),
+    layer({ id: 513, name: "b", index: 3 }),
+    layer({ id: 514, name: "c", index: 4 }),
+  ]);
+  const d = diff(before, after);
+  eq(d.added.map((a) => a.id), [512, 513, 514], "the new ids are named");
+  eq(d.added[0].name, "a", "…with their names, so a copyToComp result is identifiable");
+  eq(d.changed, undefined, "adding a layer changes nothing about the others");
+  ok(/3 layers added: ids 512-514/.test(d.summary), `consecutive ids collapse to a range: ${d.summary}`);
+}
+
+// ---------- layers removed ----------
+{
+  const before = comp([layer({ id: 1 }), layer({ id: 2, index: 2 }), layer({ id: 3, index: 3 })]);
+  const after = comp([layer({ id: 1 }), layer({ id: 3, index: 2 })]);
+  const d = diff(before, after);
+  eq(d.removed.map((r) => r.id), [2], "the removed layer is named");
+  eq(d.added, undefined);
+  eq(d.reordered, undefined, "removing a layer is not a reorder of the survivors");
+  ok(/1 layer removed: ids 2/.test(d.summary), d.summary);
+}
+
+// ---------- the per-layer fields ----------
+{
+  const cases = [
+    ["renamed", { name: "after" }, (c) => eq(c.name, { from: "L", to: "after" }), /renamed "L" -> "after"/],
+    ["retimed in", { inPoint: 1.5 }, (c) => eq(c.inPoint, { from: 0, to: 1.5 }), /retimed \(in 0 -> 1\.5\)/],
+    ["retimed out", { outPoint: 9 }, (c) => eq(c.outPoint, { from: 5, to: 9 }), /retimed \(out 5 -> 9\)/],
+    ["slipped", { startTime: 2 }, (c) => eq(c.startTime, { from: 0, to: 2 }), /retimed \(start 0 -> 2\)/],
+    ["re-parented", { parentId: 12 }, (c) => eq(c.parentId, { from: null, to: 12 }), /re-parented none -> 12/],
+    ["disabled", { enabled: false }, (c) => eq(c.enabled, { from: true, to: false }), /layer 100 disabled/],
+    ["effects added", { effectCount: 2 }, (c) => eq(c.effectCount, { from: 0, to: 2 }), /effects 0 -> 2/],
+    ["expression added", { expressionCount: 1 }, (c) => eq(c.expressionCount, { from: 0, to: 1 }), /expressions 0 -> 1/],
+  ];
+  for (const [label, over, check, phrase] of cases) {
+    const d = diff(comp([layer()]), comp([layer(over)]));
+    eq(d.changeCount, 1, `${label}: exactly one change`);
+    eq(d.changed.length, 1, `${label}: one layer changed`);
+    eq(d.changed[0].id, 100, `${label}: identified by id`);
+    check(d.changed[0].changes);
+    ok(phrase.test(d.summary), `${label}: the summary should read "${phrase}", got "${d.summary}"`);
+  }
+}
+
+// ---------- keyframe counts ----------
+{
+  const d = diff(
+    comp([layer({ id: 498, keyCounts: { Position: 2 } })]),
+    comp([layer({ id: 498, keyCounts: { Position: 2, Opacity: 4 } })]),
+  );
+  eq(d.changed[0].changes.keyCounts, { Opacity: { from: 0, to: 4 } }, "a property that gained keys reads 0 -> n");
+  ok(/layer 498 Opacity keys 0 -> 4/.test(d.summary), `the issue's own example line: ${d.summary}`);
+
+  // And the other direction: a property whose keys were all deleted drops out
+  // of keyCounts entirely, which must still read as a change to zero.
+  const gone = diff(
+    comp([layer({ keyCounts: { Position: 3 } })]),
+    comp([layer({ keyCounts: {} })]),
+  );
+  eq(gone.changed[0].changes.keyCounts, { Position: { from: 3, to: 0 } }, "deleted keyframes are a change to 0");
+}
+
+// ---------- float noise is not a change ----------
+{
+  const d = diff(comp([layer()]), comp([layer({ inPoint: 1e-9, outPoint: 5 + 1e-9 })]));
+  eq(d.changeCount, 0, "a difference below a millionth of a second is float noise, not a retime");
+}
+
+// ---------- reorder ----------
+{
+  // Two layers swapped: a genuine reorder.
+  const before = comp([layer({ id: 1 }), layer({ id: 2, index: 2 }), layer({ id: 3, index: 3 })]);
+  const after = comp([layer({ id: 2, index: 1 }), layer({ id: 1, index: 2 }), layer({ id: 3, index: 3 })]);
+  const d = diff(before, after);
+  ok(d.reordered, "swapping two layers is a reorder");
+  eq(d.reordered.map((r) => r.id).sort(), [1, 2], "…of exactly those two");
+  eq(d.reordered[0].fromIndex !== d.reordered[0].toIndex, true, "with both indices reported");
+  ok(/moved in the stack/.test(d.summary), d.summary);
+
+  // Inserting at the top shifts every index below it. That is not a reorder,
+  // and reporting it as twenty changed layers would destroy the whole point.
+  const grown = comp([
+    layer({ id: 9, name: "new", index: 1 }),
+    layer({ id: 1, index: 2 }),
+    layer({ id: 2, index: 3 }),
+    layer({ id: 3, index: 4 }),
+  ]);
+  const ins = diff(before, grown);
+  eq(ins.reordered, undefined, "an index shifted by an insertion is not a move");
+  eq(ins.changed, undefined, "and nothing about the existing layers changed");
+  eq(ins.unchangedLayers, 3, "they are counted as unchanged");
+  eq(ins.added.length, 1);
+}
+
+// ---------- comp-level fields ----------
+{
+  const d = diff(comp([]), comp([], { duration: 20, name: "Renamed" }));
+  eq(d.comp.duration, { from: 10, to: 20 });
+  eq(d.comp.name, { from: "Main", to: "Renamed" });
+  ok(/comp duration 10 -> 20/.test(d.summary), d.summary);
+
+  const sized = diff(comp([]), comp([], { width: 1080, height: 1920 }));
+  eq(sized.comp.size, { from: [1920, 1080], to: [1080, 1920] });
+
+  const markers = diff(comp([], { markers: ["0|a|0"] }), comp([], { markers: ["0|a|0", "1|b|0"] }));
+  eq(markers.comp.markers, { from: 1, to: 2 }, "a marker count change is reported");
+  const edited = diff(comp([], { markers: ["0|a|0"] }), comp([], { markers: ["0|b|0"] }));
+  eq(edited.comp.markers, { count: 1, edited: true }, "the same count with different content still counts");
+}
+
+// ---------- the summary stays one readable line ----------
+{
+  const many = [];
+  const changed = [];
+  for (let i = 0; i < 20; i++) {
+    many.push(layer({ id: 200 + i, index: i + 1 }));
+    changed.push(layer({ id: 200 + i, index: i + 1, name: "renamed " + i }));
+  }
+  const d = diff(comp(many), comp(changed));
+  eq(d.changed.length, 20, "every change is still in the structured fields");
+  ok(/and 12 more changes \(see the fields below\)/.test(d.summary), `the prose is capped: ${d.summary}`);
+  ok(d.summary.length < 700, `and stays short: ${d.summary.length} chars`);
+}
+
+// ---------- id ranges ----------
+{
+  const idList = call("__diffIdList");
+  eq(idList([512, 513, 514]), "512-514", "a run collapses");
+  eq(idList([514, 512, 513]), "512-514", "…whatever order they arrive in");
+  eq(idList([1, 2]), "1, 2", "two consecutive ids are clearer spelled out");
+  eq(idList([1, 5, 6, 7, 20]), "1, 5-7, 20", "runs and singletons mix");
+  eq(idList([42]), "42");
+}
+
+// ---------------------------------------------------------------------------
+// diff:true on the write ops
+// ---------------------------------------------------------------------------
+{
+  const start = call("__diffStart");
+  const finish = call("__diffFinish");
+
+  eq(start({}, null), null, "no diff asked for, no work done");
+  eq(start({ diff: false }, null), null, "…and false means false");
+
+  // Nothing to fingerprint: refused with a reason, never silently skipped. A
+  // missing diff that looks like "nothing changed" is the failure this exists
+  // to prevent.
+  vm.runInContext("setProject([], null);", ctx);
+  const none = plain(finish(start({ diff: true }, null)));
+  eq(none.unavailable, true, "with no comp to look at, the diff says so");
+  ok(/diffCompId/.test(none.reason), "and names the way to fix it");
+  ok(/No diff was taken/.test(none.summary), none.summary);
+
+  // A batch names its own comps in its ops.
+  vm.runInContext(
+    `
+    var c1 = mkComp({ id: 21, name: "One", layers: [mkLayer("shape", { id: 1, name: "a", index: 1 })] });
+    var c2 = mkComp({ id: 22, name: "Two", layers: [] });
+    setProject([c1, c2], c2);
+    var OPS_ARGS = [{ op: "x", args: { compId: 21 } }, { op: "y", args: { compId: 21 } }, { op: "z", args: { compId: 22 } }];
+    `,
+    ctx,
+  );
+  const fromOps = start({ diff: true }, call("OPS_ARGS"));
+  eq(plain(fromOps.ids), [21, 22], "each comp the batch names, once");
+
+  // An explicit diffCompId outranks both.
+  eq(plain(start({ diff: true, diffCompId: 22 }, call("OPS_ARGS")).ids), [22], "diffCompId wins");
+
+  // …and with neither, the comp open in the viewer.
+  eq(plain(start({ diff: true }, null).ids), [22], "otherwise the active comp");
+
+  // One comp in, one diff out — not a list of one.
+  const single = plain(finish(start({ diff: true, diffCompId: 21 }, null)));
+  eq(single.compId, 21, "a single-comp diff is returned bare");
+  eq(single.changeCount, 0);
+
+  // Several comps in, one wrapper out with a combined line.
+  const multi = plain(finish(fromOps));
+  eq(multi.comps.length, 2, "a multi-comp diff lists them");
+  ok(/comp 21: /.test(multi.summary) && /comp 22: /.test(multi.summary), multi.summary);
+
+  // A comp deleted between the two fingerprints is reported, not thrown.
+  const across = start({ diff: true, diffCompId: 21 }, null);
+  vm.runInContext("setProject([c2], c2);", ctx);
+  const deleted = plain(finish(across));
+  eq(deleted.gone, true, "a comp that vanished mid-call is reported as gone");
+  ok(/no longer be read/.test(deleted.summary), deleted.summary);
+}
+
+// ---------- the error annotation ----------
+{
+  vm.runInContext(
+    `
+    var c3 = mkComp({ id: 31, name: "Live", layers: [mkLayer("shape", { id: 1, name: "a", index: 1 })] });
+    setProject([c3], c3);
+    `,
+    ctx,
+  );
+  const state = call("__diffStart")({ diff: true, diffCompId: 31 }, null);
+  // The script adds a layer and then throws — nothing rolls back.
+  vm.runInContext(
+    `
+    var c3b = mkComp({ id: 31, name: "Live", layers: [
+      mkLayer("shape", { id: 1, name: "a", index: 1 }),
+      mkLayer("shape", { id: 2, name: "b", index: 2 })
+    ] });
+    setProject([c3b], c3b);
+    `,
+    ctx,
+  );
+  const err = new Error("boom");
+  err.line = 12;
+  call("__diffAnnotateError")(err, state);
+  ok(/boom/.test(err.message), "the original message survives");
+  ok(/1 layer added: ids 2/.test(err.message), `the stop point is on the error: ${err.message}`);
+  ok(/nothing rolls back/.test(err.message), "and says re-running is not the fix");
+  eq(err.line, 12, "the error object is mutated, not replaced — line and stack survive for the caller");
+
+  // With no diff requested there is nothing to annotate and nothing to say.
+  const clean = new Error("boom");
+  call("__diffAnnotateError")(clean, null);
+  eq(clean.message, "boom", "no diff asked for, no noise added");
+}
+
+// ---------- run_jsx's envelope ----------
+{
+  const withDiff = call("__rjWithDiff");
+  const d = intoVm({ summary: "x", changeCount: 0 });
+
+  const scalar = plain(withDiff(7, d, "AE MCP: run_jsx"));
+  eq(scalar.returned, 7, "a scalar return value has nowhere to hang a diff, so it is enveloped");
+  eq(scalar.ok, true);
+  eq(scalar.undoGroup, "AE MCP: run_jsx");
+  ok(scalar.diff, "…with the diff beside it");
+
+  const arr = plain(withDiff(intoVm([1, 2]), d, false));
+  eq(arr.returned, [1, 2], "an array is a value, not an envelope to extend");
+  eq(arr.undoGroup, false, "undoGroup:false is carried through as false");
+
+  // __rjResult's own null envelope is already the right shape; extending it
+  // beats nesting one envelope inside another.
+  const nullEnv = intoVm({ ok: true, returned: null, undoGroup: "AE MCP: run_jsx", note: "Completed with no return" });
+  const extended = plain(withDiff(nullEnv, d, "AE MCP: run_jsx"));
+  eq(extended.returned, null);
+  ok(extended.note, "the note that says it did not fail is kept");
+  ok(extended.diff, "and the diff joins it at the top level");
+  ok(extended.returned === null, "never an envelope nested inside a second envelope");
+}
+
+// ---------------------------------------------------------------------------
+// Where the snapshots are kept
+// ---------------------------------------------------------------------------
+// In the MCP server's memory, not in the After Effects project — a tool that
+// reads the project must not modify it. The cost of that is a lifetime of one
+// session, which is fine, but only if it is never met as a cryptic failure.
+{
+  // pathToFileURL, not the bare path: on Windows an absolute path starts with a
+  // drive letter, which the ESM loader reads as an unsupported URL scheme.
+  const { SnapshotStore } = await import(
+    pathToFileURL(path.join(root, "packages", "mcp-server", "dist", "snapshots", "store.js")).href
+  );
+
+  const store = new SnapshotStore(3);
+  const fp = (compId, layers) => ({ compId, name: "Main", numLayers: layers, layers: new Array(layers).fill({}) });
+
+  const first = store.store(fp(7, 2));
+  eq(first.compId, 7, "the comp is remembered with the fingerprint");
+  eq(first.layerCount, 2);
+  ok(store.get(first.id).fingerprint, "…and the fingerprint itself is what comes back");
+  eq(store.get("nope"), undefined, "an id that was never issued is simply absent");
+
+  const ids = [first.id];
+  for (let i = 0; i < 3; i++) ids.push(store.store(fp(7, 1)).id);
+  eq(store.size(), 3, "the table is bounded");
+  eq(store.get(ids[0]), undefined, "and it is the oldest that goes");
+  ok(store.get(ids[3]), "the newest is kept");
+
+  // The message an agent meets after doing the work it wanted to verify. It has
+  // to explain and then point somewhere, or it strands them.
+  const msg = store.missingMessage(ids[0]);
+  ok(msg.includes(ids[0]), "the message names the id that was asked for");
+  ok(/length of the session/.test(msg), "…says why it is gone");
+  ok(/oldest is dropped once 3 are held/.test(msg), "…including the other reason");
+  ok(/snapshot_comp/.test(msg) && /list_layers/.test(msg), "…and names both ways forward");
+  ok(store.ids().every((id) => msg.includes(id)), "the ids that ARE held are listed, so the next call can succeed");
+
+  eq(new SnapshotStore(3).missingMessage("snap_1").includes("No snapshots are held"), true,
+    "a fresh session says that rather than listing nothing");
+}
+
+console.log(`comp-snapshot: ${passed} assertions passed`);

--- a/tests/unit/duplicate-comp.mjs
+++ b/tests/unit/duplicate-comp.mjs
@@ -1,0 +1,325 @@
+// duplicate_comp, out of packages/jsx/comps.jsx.
+//
+// AE's own CompItem.duplicate() is SHALLOW: the copy's precomp layers point at
+// the same nested comps as the original, so "make a variant of this rig" and
+// then editing the variant silently edits the original too. `deep:true` is
+// where all the risk lives, and three of its failure modes are invisible in a
+// screenshot:
+//
+//   - Fan-out. The same nested comp usually appears on several layers. A naive
+//     walk duplicates it once per reference and the variant ends up with three
+//     unrelated copies of one beat comp.
+//   - Cycles. The `seen` map is the guard, and the copy has to be registered
+//     BEFORE recursing into it or a cycle recurses for ever.
+//   - Half-success. If a nested duplication fails part-way, the comps already
+//     created are real and nothing rolled them back. Reporting {ok:true} over
+//     that, or an error that does not name what exists, is the same class of
+//     lie as swallowing the error.
+//
+// There is no ExtendScript runtime on a runner, so After Effects is stubbed
+// down to what the walk actually uses: duplicate(), layer(i), source,
+// replaceSource() and the project's item list.
+//
+//   node tests/unit/duplicate-comp.mjs
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const read = (f) => fs.readFileSync(path.join(root, "packages", "jsx", f), "utf8");
+
+let passed = 0;
+const ok = (cond, msg) => { assert.ok(cond, msg); passed++; };
+const eq = (a, b, msg) => { assert.deepEqual(a, b, msg); passed++; };
+
+// A fresh fake project per case: these tests mutate it.
+function load() {
+  const ctx = { OPS: {}, noUndo: (fn) => fn, noUndoWhen: (p, fn) => fn, undoNamed: (n, fn) => fn };
+  vm.createContext(ctx);
+  vm.runInContext(
+    `
+    function CompItem() {}
+    function FolderItem() {}
+    function FootageItem() {}
+    function AVLayer() {}
+    function TextLayer() {}
+    function ShapeLayer() {}
+    function CameraLayer() {}
+    function LightLayer() {}
+
+    var NEXT_ID = 1000;
+    var ITEMS = [];
+    var FAIL_ON = null;          // name of a comp whose duplicate() should throw
+
+    function addItem(it) { ITEMS.push(it); return it; }
+
+    function mkLayer(name, source) {
+      var l = new AVLayer();
+      l.name = name;
+      l.source = source || null;
+      l.replaceSource = function (next, fixExpressions) {
+        l.source = next;
+        l.fixExpressions = fixExpressions;
+      };
+      return l;
+    }
+
+    function mkFolder(name) {
+      var f = new FolderItem();
+      NEXT_ID += 1;
+      f.id = NEXT_ID;
+      f.name = name;
+      return addItem(f);
+    }
+
+    function mkFootage(name) {
+      var f = new FootageItem();
+      NEXT_ID += 1;
+      f.id = NEXT_ID;
+      f.name = name;
+      return addItem(f);
+    }
+
+    function mkComp(name, layers) {
+      var c = new CompItem();
+      NEXT_ID += 1;
+      c.id = NEXT_ID;
+      c.name = name;
+      c.width = 1920; c.height = 1080; c.pixelAspect = 1;
+      c.duration = 10; c.frameRate = 30;
+      c.workAreaStart = 0; c.workAreaDuration = 10;
+      c.bgColor = [0, 0, 0];
+      c.parentFolder = null;
+      c._layers = layers || [];
+      c.numLayers = c._layers.length;
+      c.layer = function (i) { return c._layers[i - 1]; };
+      // AE's duplicate: a new comp with new layers pointing at the SAME sources.
+      c.duplicate = function () {
+        if (FAIL_ON === c.name) throw new Error("After Effects refused to duplicate " + c.name);
+        var copies = [];
+        for (var i = 0; i < c._layers.length; i++) copies.push(mkLayer(c._layers[i].name, c._layers[i].source));
+        return mkComp(c.name + " 2", copies);
+      };
+      return addItem(c);
+    }
+
+    var app = {
+      project: {
+        get numItems() { return ITEMS.length; },
+        item: function (i) { return ITEMS[i - 1]; },
+        itemByID: function (id) {
+          for (var i = 0; i < ITEMS.length; i++) { if (ITEMS[i].id === id) return ITEMS[i]; }
+          return null;
+        }
+      }
+    };
+
+    function comps() {
+      var out = [];
+      for (var i = 0; i < ITEMS.length; i++) { if (ITEMS[i] instanceof CompItem) out.push(ITEMS[i]); }
+      return out;
+    }
+    function byName(name) {
+      var hits = [];
+      for (var i = 0; i < ITEMS.length; i++) { if (ITEMS[i].name === name) hits.push(ITEMS[i]); }
+      return hits;
+    }
+    `,
+    ctx,
+  );
+  vm.runInContext(read("ids.jsx"), ctx, { filename: "ids.jsx" });
+  vm.runInContext(read("comps.jsx"), ctx, { filename: "comps.jsx" });
+  vm.runInContext(read("explore.jsx"), ctx, { filename: "explore.jsx" });
+  const run = (args) => JSON.parse(JSON.stringify(vm.runInContext("OPS.duplicate_comp", ctx)(args)));
+  return { ctx, run, get: (expr) => vm.runInContext(expr, ctx) };
+}
+
+// ---------- shallow, the default ----------
+{
+  const { ctx, run, get } = load();
+  vm.runInContext(
+    `
+    var beat = mkComp("Beat", []);
+    var main = mkComp("Main", [mkLayer("beat A", beat), mkLayer("beat B", beat)]);
+    `,
+    ctx,
+  );
+  const before = get("comps().length");
+  const res = run({ compId: get("main.id") });
+
+  eq(get("comps().length"), before + 1, "exactly one comp is created");
+  eq(res.name, "Main 2", "AE's own naming stands when none is given");
+  eq(res.fromCompId, get("main.id"), "the source is named in the result");
+  ok(typeof res.id === "number", "the new comp id comes back, so nobody has to find it by name");
+  eq(res.deep, false);
+  eq(res.nestedDuplicated, undefined, "a shallow copy duplicated nothing nested");
+  ok(/still point at the SAME nested comps/.test(res.note), "and the sharing is stated, not left to be discovered");
+
+  // The copy's layers still point at the original nested comp — that IS the
+  // shallow contract, and the reason deep exists.
+  const shared = get(`(function () {
+    var dup = app.project.itemByID(${res.id});
+    return dup.layer(1).source === beat && dup.layer(2).source === beat;
+  })()`);
+  eq(shared, true, "shallow means shared, exactly like AE's Duplicate");
+}
+
+// ---------- name and folder ----------
+{
+  const { ctx, run, get } = load();
+  vm.runInContext(`var folder = mkFolder("Rigs"); var main = mkComp("Main", []);`, ctx);
+  const res = run({ compId: get("main.id"), name: "Scene 4", folderId: get("folder.id") });
+  eq(res.name, "Scene 4", "an explicit name is used");
+  eq(res.folderName, "Rigs", "and the folder it was filed in is reported");
+  eq(get(`app.project.itemByID(${res.id}).parentFolder.name`), "Rigs", "…because it really was moved");
+}
+
+// ---------- folderId has to be a folder ----------
+{
+  const { ctx, get } = load();
+  vm.runInContext(`var other = mkComp("Other", []); var main = mkComp("Main", []);`, ctx);
+  const call = (args) => vm.runInContext("OPS.duplicate_comp", ctx)(args);
+
+  assert.throws(
+    () => call({ compId: get("main.id"), folderId: get("other.id") }),
+    (e) => /not a project folder/.test(e.message) && /Other/.test(e.message) && /comp/.test(e.message),
+    "a comp id passed as folderId must fail loudly, naming the id and what it actually is",
+  );
+  passed++;
+  assert.throws(
+    () => call({ compId: get("main.id"), folderId: 999999 }),
+    /No project item with id 999999/,
+    "an id that is nothing at all is named too",
+  );
+  passed++;
+  eq(vm.runInContext("comps().length", ctx), 2, "and nothing was created on the way to the error");
+}
+
+// ---------- deep: nested comps are duplicated and re-pointed ----------
+{
+  const { ctx, run, get } = load();
+  vm.runInContext(
+    `
+    var logo = mkFootage("logo.png");
+    var inner = mkComp("Inner", [mkLayer("art", logo)]);
+    var beat = mkComp("Beat", [mkLayer("inner", inner)]);
+    var main = mkComp("Main", [mkLayer("beat", beat), mkLayer("still", logo)]);
+    `,
+    ctx,
+  );
+  const res = run({ compId: get("main.id"), name: "Main variant", deep: true });
+
+  eq(res.deep, true);
+  eq(res.nestedCount, 2, "Beat and Inner are both duplicated — the walk recurses");
+  eq(res.layersRepointed, 2, "one precomp layer in the copy, one in the copy of Beat");
+
+  const wired = get(`(function () {
+    var dup = app.project.itemByID(${res.id});
+    var newBeat = dup.layer(1).source;
+    return {
+      beatIsFresh: newBeat !== beat,
+      innerIsFresh: newBeat.layer(1).source !== inner,
+      footageShared: dup.layer(2).source === logo,
+      fixExpressions: dup.layer(1).fixExpressions
+    };
+  })()`);
+  eq(wired.beatIsFresh, true, "the copy points at its own Beat, not the original");
+  eq(wired.innerIsFresh, true, "and that copy points at its own Inner — the recursion reaches the bottom");
+  eq(wired.footageShared, true, "footage is never duplicated; only comps are");
+  eq(wired.fixExpressions, false, "replaceSource must not be allowed to rewrite the rig's expressions");
+
+  const names = res.nestedDuplicated.map((n) => n.fromName).sort();
+  eq(names, ["Beat", "Inner"], "every nested duplication is reported, with where it came from");
+}
+
+// ---------- deep: the same nested comp on several layers is duplicated once ----------
+{
+  const { ctx, run, get } = load();
+  vm.runInContext(
+    `
+    var beat = mkComp("Beat", []);
+    var main = mkComp("Main", [mkLayer("a", beat), mkLayer("b", beat), mkLayer("c", beat)]);
+    `,
+    ctx,
+  );
+  const res = run({ compId: get("main.id"), deep: true });
+
+  eq(res.nestedCount, 1, "one nested comp used three times is duplicated once, not three times");
+  eq(res.layersRepointed, 3, "…and all three layers are re-pointed at it");
+  const oneSource = get(`(function () {
+    var dup = app.project.itemByID(${res.id});
+    return dup.layer(1).source === dup.layer(2).source && dup.layer(2).source === dup.layer(3).source;
+  })()`);
+  eq(oneSource, true, "so the variant shares one beat comp, exactly as the original did");
+}
+
+// ---------- deep: a cycle terminates ----------
+{
+  const { ctx, run, get } = load();
+  // AE refuses to nest a comp inside itself, but the guard must not depend on
+  // that: the copy is registered before the walk descends into it.
+  vm.runInContext(
+    `
+    var loop = mkComp("Loop", []);
+    loop._layers = [mkLayer("self", loop)];
+    loop.numLayers = 1;
+    var main = mkComp("Main", [mkLayer("loop", loop)]);
+    `,
+    ctx,
+  );
+  const res = run({ compId: get("main.id"), deep: true });
+  eq(res.nestedCount, 1, "a self-referencing comp is duplicated once and reused, not recursed into for ever");
+  passed++;
+}
+
+// ---------- deep: nameSuffix, and never two items with the same name ----------
+{
+  const { ctx, run, get } = load();
+  vm.runInContext(
+    `
+    var beat = mkComp("Beat", []);
+    var main = mkComp("Main", [mkLayer("beat", beat)]);
+    var collide = mkComp("Beat [v2]", []);
+    `,
+    ctx,
+  );
+  const res = run({ compId: get("main.id"), name: "Main [v2]", deep: true, nameSuffix: " [v2]" });
+  eq(res.name, "Main [v2]");
+  eq(
+    res.nestedDuplicated[0].name,
+    "Beat [v2] 2",
+    "the suffixed name was already taken, so a counter is appended rather than shipping two identical names",
+  );
+  eq(get(`byName("Beat [v2]").length`), 1, "and the existing item keeps its name");
+}
+
+// ---------- deep: a half-built rig is never reported as a success ----------
+{
+  const { ctx, get } = load();
+  vm.runInContext(
+    `
+    var good = mkComp("Good", []);
+    var bad = mkComp("Bad", []);
+    var main = mkComp("Main", [mkLayer("good", good), mkLayer("bad", bad)]);
+    FAIL_ON = "Bad";
+    `,
+    ctx,
+  );
+  const before = get("comps().length");
+  assert.throws(
+    () => vm.runInContext("OPS.duplicate_comp", ctx)({ compId: get("main.id"), deep: true }),
+    (e) =>
+      /failed part-way/.test(e.message) &&
+      /still exist: ids /.test(e.message) &&
+      /Undo once in After Effects/.test(e.message) &&
+      /refused to duplicate Bad/.test(e.message),
+    "a deep duplication that fails must name what was created, why, and how to back it out",
+  );
+  passed++;
+  eq(get("comps().length"), before + 2, "the copies made before the failure really do still exist");
+}
+
+console.log(`duplicate-comp: ${passed} assertions passed`);

--- a/tests/unit/jsx-undo-group.mjs
+++ b/tests/unit/jsx-undo-group.mjs
@@ -18,6 +18,10 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const core = fs.readFileSync(path.join(root, "packages", "jsx", "core.jsx"), "utf8");
+// raw.jsx calls into snapshot.jsx for run_jsx's opt-in diff. In After Effects
+// both are halves of one concatenated bundle; here they have to be loaded
+// explicitly, or every run_jsx call fails on an undefined helper.
+const snapshot = fs.readFileSync(path.join(root, "packages", "jsx", "snapshot.jsx"), "utf8");
 const raw = fs.readFileSync(path.join(root, "packages", "jsx", "raw.jsx"), "utf8");
 
 function load() {
@@ -31,6 +35,7 @@ function load() {
   };
   vm.createContext(ctx);
   vm.runInContext(core, ctx, { filename: "core.jsx" });
+  vm.runInContext(snapshot, ctx, { filename: "snapshot.jsx" });
   vm.runInContext(raw, ctx, { filename: "raw.jsx" });
   const call = (op, args) =>
     vm.runInContext("dispatch", ctx)(JSON.stringify({ op, args }));


### PR DESCRIPTION
Closes #52
Closes #54

## What this adds

**`snapshot_comp` / `diff_comp` (#52).** A cheap structural fingerprint of a comp and the diff between two of them. Per layer: `id, name, index, type, inPoint, outPoint, startTime, parentId, enabled, keyCounts, expressionCount, effectCount`; per comp: name, size, duration, frame rate, work area, markers. The diff reports only what moved — layers added (with ids and names), removed, renamed, retimed, re-parented, keyframe counts that changed, expressions and effects gained or lost — and counts the unchanged layers rather than listing them. Every diff carries a one-line `summary` in the shape the issue asked for: `3 layers added: ids 512-514; layer 498 Opacity keys 0 -> 4`.

**`duplicate_comp` (#54).** `{compId, name?, folderId?, deep?, nameSuffix?}` → the new comp id, so nobody has to find the copy by name. One undo step. `deep:true` duplicates the nested precomps and re-points the copy's layers at them.

## Design decisions worth reviewing

**The snapshot lives in the MCP server, not in the .aep.** Only the panel can read AE, so the gathering happens there; but writing a fingerprint into the project would make a *read* tool modify the user's file and undo stack for scaffolding nobody wants to keep. So these are the first **half server-resident** ops: `SNAPSHOT_OPS` in `server.ts` routes them to `runSnapshotOp`, which forwards an internal `_comp_fingerprint` / `_comp_diff` and holds the answer in the new `SnapshotStore`. They are deliberately *not* in `SERVER_OPS` — unlike those, they do touch the bridge — and they are dispatched from inside the same `try` as `bridge.runOp`, so the timeout, `AeError` and Unknown-op mappings apply unchanged.

**Lifetime is one session, and it is never a cryptic failure.** A bounded ring of 32. `missingMessage()` says why the id is gone, lists the ids that *are* held, and names both ways forward (take a fresh snapshot, or read the comp back — a diff can only compare against a snapshot taken beforehand). That method is the reason the store is a class rather than a `Map`.

**The fingerprint is returned only when asked.** `includeFingerprint:true`. Returning it by default would reintroduce exactly the context cost the tool exists to remove.

**`diff:true` on `run_jsx` / `run_batch` fingerprints inside the same call.** A before-snapshot taken by a separate `snapshot_comp` is a second round-trip during which anything can happen. So before/write/after is one bridge call and the diff logic lives in `snapshot.jsx`. The touch on the two hot handlers is deliberately tiny: `raw.jsx` gains 7 lines replacing one `return`, `batch.jsx` gains a `__diffStart` call, a `diffState` field on the job record, and `out.diff` on three return paths. **Merge note for the parallel `run_jsx` work (#46/#53):** my `raw.jsx` change is confined to the last statement of `OPS.run_jsx`, and my `RunJsx` schema change is two appended keys (`diff`, `diffCompId`). Nothing else in either file moved.

**A failed write still gets its diff.** Nothing rolls back, so "where did it stop" is the most valuable question after a throw — one of the three cases the issue was opened for. `__diffAnnotateError` **mutates** the error's `message` and rethrows the *same object*, so `line` and `stack` survive for `__mkError`. That matters for #46/#53: the line-number fix is not disturbed by this.

**A diff is the extreme case of a scoped read, so it says what it left out.** `covers` travels with every diff and `snapshot_comp` returns the long form. When nothing moved, the summary reads "No differences in the recorded fields … so this is not a claim that nothing changed at all" rather than anything that could be read as "identical". The walk **never** opens an effect's parameters or a shape layer's `Contents` — a fingerprint costing as much as the read it replaces is worth nothing — and the unit test puts probes on both accessors so a later edit cannot quietly start walking them.

**`index` is recorded but never diffed directly.** Inserting one layer shifts every index below it; diffing indices would report twenty changed layers for one addition. Relative order is compared separately, so a genuine reorder is reported and an insertion is not.

**`duplicate_comp` keeps AE's shallow default but says so.** The result of a shallow copy carries a note that its precomp layers still point at the *same* nested comps. `deep:true` keys its map by the **original** comp id and registers the copy *before* recursing, which is what makes a comp used by several layers duplicate once instead of fanning out, and what makes a cycle terminate. `folderId` is validated as a `FolderItem` and fails naming the id and what it actually is. A deep duplication that fails part-way throws an error naming every comp it created — those objects are real and nothing rolled them back.

## Verified offline

- `npm run build` and `npm test` pass. 208 new assertions across two new test files, appended to the end of the root `test` chain.
- `tests/unit/comp-snapshot.mjs` (144): the fingerprint against a stubbed AE (fields, key counts, expression/effect counts, real `__layerKind`, and the two "must never be walked" probes); the diff against synthetic fingerprints for no-change, added, removed, renamed, retimed ×3, re-parented, disabled, effects, expressions, key counts up **and** down to zero, float noise below epsilon, genuine reorder vs. index shift from an insertion, comp-level name/size/duration/markers, the summary cap, and id-range collapsing; `__diffStart` / `__diffFinish` for explicit `diffCompId`, batch-derived ids, active comp, nothing-available, multi-comp, and a comp deleted mid-call; the error annotation preserving `line`; `__rjWithDiff` for scalar, array and null-envelope returns; and `SnapshotStore` eviction and `missingMessage`.
- `tests/unit/duplicate-comp.mjs` (32): shallow sharing, name and folder, both `folderId` rejections, deep re-pointing to the bottom of the tree, footage never duplicated, `replaceSource(…, false)`, fan-out avoided, cycle terminates, `nameSuffix` collision handling, and the half-success error naming what exists.
- MCP server starts, serves 73 tools, and all five schemas (3 new tools + the two new params on `run_jsx`/`run_batch`) generate valid draft-2020-12 JSON Schema.
- `esbuild` bundles the server cleanly with the new module.
- `jsx-ternary` and `bundle-determinism` still pass with `snapshot.jsx` in the bundle (20 modules).

`tests/unit/jsx-undo-group.mjs` now loads `snapshot.jsx` alongside `core.jsx` and `raw.jsx` — in AE they are halves of one concatenated bundle, but in the VM they have to be loaded explicitly.

## UNVERIFIED — After Effects was not available

**None of this has been run against After Effects.** Another agent was driving a live AE session on this machine throughout, so nothing here was executed in AE, and the panel was not installed or reloaded. Everything below is reasoned from AE's scripting API and the existing code, not measured:

- That `CompItem.duplicate()` behaves as modelled (a shallow copy whose precomp layers point at the original sources) and that `AVLayer.replaceSource(comp, false)` re-points a precomp layer without disturbing its keyframes, effects or in/out points.
- That `parentFolder = folder` moves the duplicate, and that no handle held across `duplicate()` goes stale (the code re-fetches by id regardless, per the `export_mogrt` precedent).
- Whether `CompItem.markerProperty`, `layer.property("Time Remap")` and `layer.property("Source Text")` behave as guarded on every layer type — all four extra property reads are wrapped in `try`/`catch` and degrade to "not recorded".
- The real cost of a fingerprint on a large comp. It is one `property()` walk of Transform plus four named lookups plus `Effects.numProperties` per layer, with no effect-parameter or shape walk, but that has not been timed.
- Whether `app.project.activeItem` is a useful default for `run_jsx({diff:true})` in practice.
- The interaction of `diff:true` with the >500-op async job path (`diffState` is carried on the `JOBS` record and finished in `_continue_job`).

**Manual verification recipes** are in `CLAUDE.md` as 21, 22 and 23, in the style of the existing ones, and should be run against a live AE 2026 before release.

## Deliberately not done

- No edits to `packages/mcp-server/src/guides/`, `src/prompts/`, `src/generated/content.ts`, `plugin/` or `GUIDE_TOPICS` — another agent owns those. The new tools are therefore documented in their tool descriptions and in `CLAUDE.md`, but not yet in the `after-effects` guide; that is worth a follow-up.
- The "70 tools" line in `CLAUDE.md` is left alone (it is now 73) to avoid a six-way conflict across the parallel PRs. CI still checks `>= 70`.
- No `SLOW_OPS` entry for the new ops; they are ordinary reads well inside the 120s default.
